### PR TITLE
fix: quarantine mechs with unreachable IPFS tools manifests

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihyrzrlurexsr6yeszjarbq3wvoq3idbdjht5jdzdc4lcdtypxbnu"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeig2ow25hty45fglfyhcqzxro66pvus5ypmgnwjlqhjuuhz4nxwkjy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -28,10 +28,10 @@
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/agent_mech/0.1.0": "bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m",
-        "contract/valory/agent_registry/0.1.0": "bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi",
+        "contract/valory/agent_registry/0.1.0": "bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi",
         "contract/valory/service_registry/0.1.0": "bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e",
         "contract/valory/gnosis_safe/0.1.0": "bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y",
-        "contract/valory/erc20/0.1.0": "bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy",
+        "contract/valory/erc20/0.1.0": "bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihooc4xsvgib3nlppehqsamvnvi56woj2h76g742237nmc5ppinke"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiaqjbii6revydvpwvitqr4e5eb7iqkjti7voymxqr4xt4dmpqryzu"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiaqjbii6revydvpwvitqr4e5eb7iqkjti7voymxqr4xt4dmpqryzu"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihyrzrlurexsr6yeszjarbq3wvoq3idbdjht5jdzdc4lcdtypxbnu"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibygyyo2q7hxwdeynskbzjuohor7dak56u6oqj7hwndfy3ktb5xvi"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiepc52s5ipp2jk5d23aqscjmcxmsdpozx5kf75w4h5fgcvxiukczi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -28,10 +28,10 @@
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/agent_mech/0.1.0": "bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m",
-        "contract/valory/agent_registry/0.1.0": "bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi",
+        "contract/valory/agent_registry/0.1.0": "bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi",
         "contract/valory/service_registry/0.1.0": "bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e",
         "contract/valory/gnosis_safe/0.1.0": "bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y",
-        "contract/valory/erc20/0.1.0": "bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu",
+        "contract/valory/erc20/0.1.0": "bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeig2ow25hty45fglfyhcqzxro66pvus5ypmgnwjlqhjuuhz4nxwkjy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibygyyo2q7hxwdeynskbzjuohor7dak56u6oqj7hwndfy3ktb5xvi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -98,8 +98,13 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
 
             if len(res) == 0:
                 self.context.logger.warning(
-                    f"The {mech.address} mech agent's tools are empty!"
+                    f"Quarantining mech {mech.address}: tools manifest at "
+                    f"{self.mech_tools_api.url} is empty. Empty lists are "
+                    f"deterministic per-CID; will retry on next round entry."
                 )
+                self._failed_mechs.add(mech.address)
+                self.mech_tools_api.reset_retries()
+                continue
 
             # store only the relevant mech tools
             relevant_tools = set(res) - self.params.irrelevant_tools

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -21,7 +21,7 @@
 """This module contains the behaviour responsible for gathering information about the mech marketplace."""
 
 import json
-from typing import Any, Generator, Optional
+from typing import Any, Generator, Optional, Set
 
 from packages.valory.skills.mech_interact_abci.behaviours.base import (
     MechInteractBaseBehaviour,
@@ -54,6 +54,7 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         """Initialize Behaviour."""
         super().__init__(**kwargs)
         self._fetch_status: FetchStatus = FetchStatus.NONE
+        self._failed_mechs: Set[str] = set()
 
     @property
     def mech_tools_api(self) -> MechToolsSpecs:  # pragma: no cover
@@ -73,7 +74,7 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
     ) -> WaitableConditionType:
         """Populate the tools of the mech info, using the metadata."""
         for mech in mech_info:
-            if mech.relevant_tools:
+            if mech.relevant_tools or mech.address in self._failed_mechs:
                 continue
 
             self.set_mech_agent_specs(mech.service.metadata_str)
@@ -85,6 +86,14 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                 msg = f"Could not get the {mech.address} mech agent's tools from {self.mech_tools_api.url}."
                 self.context.logger.warning(msg)
                 self.mech_tools_api.increment_retries()
+                if self.mech_tools_api.is_retries_exceeded():
+                    self.context.logger.error(
+                        f"Quarantining mech {mech.address}: could not fetch "
+                        f"tools manifest from {self.mech_tools_api.url} "
+                        f"after retries exhausted."
+                    )
+                    self._failed_mechs.add(mech.address)
+                    self.mech_tools_api.reset_retries()
                 return False
 
             if len(res) == 0:
@@ -113,17 +122,20 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
             return None
 
         while True:
-            # fails even if a single mech's set of tools cannot be fetched
             tools_populated = yield from self.populate_tools(mech_info)
             if tools_populated:
                 break
 
-            if not self.mech_tools_api.is_retries_exceeded():
-                continue
+        if self._failed_mechs:
+            self.context.logger.warning(
+                f"Skipped {len(self._failed_mechs)} mech(s) with unreachable "
+                f"tools manifests: {sorted(self._failed_mechs)}"
+            )
 
-            msg = "Retries were exceeded while trying to get the mech tools."
-            self.context.logger.warning(msg)
-            self.mech_tools_api.reset_retries()
+        if not any(mech.relevant_tools for mech in mech_info):
+            self.context.logger.warning(
+                "No mechs have usable tools after fetch; emitting NONE to retry."
+            )
             return None
 
         # truncate the information, otherwise logs get too big
@@ -151,3 +163,4 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
     def clean_up(self) -> None:  # pragma: no cover
         """Clean up the behaviour."""
         self.mech_tools_api.reset_retries()
+        self._failed_mechs.clear()

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeiayjajfzmziihffr5a7yxq7rh7ie757xqeoeejtmy2wcmnbg7jpiq
+  tests/test_mech_info_behaviour.py: bafybeid3iodt57epbhi47w6kdorqovqjdc6jtqmeurmtzgnsuimh2ibiyi
   tests/test_models.py: bafybeidzxsxhwwm2rbrgn5wpoyojk6jvtimfcycpbhnskg3ioz2swuqlmy
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
+- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
+- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
+- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
+- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeifrks6n275flc74hvgsncomomauzvyq54s36zt4yk2tiptuf6ez54
+  tests/test_mech_info_behaviour.py: bafybeihcby7wbfcfyf3dn2szwncchcvrfigeh6kferyx4cg4ohaldmiawy
   tests/test_models.py: bafybeidzxsxhwwm2rbrgn5wpoyojk6jvtimfcycpbhnskg3ioz2swuqlmy
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeih7xiaxbje24kybuf4mcthira3ocg4i6xuwpn2l2dlw5wxxvf52rm
+  behaviours/mech_info.py: bafybeicxuzmykkmohxmqgcunukhvb2cfta52shclfnp5hd4yh5632yq3nm
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeignu6dmihcpn7ypbjtlv2z6mmo6uos2gkdn3m2bxydconalbdgkyu
   behaviours/request.py: bafybeic7rogh4ecofc36kymolnl6oxtqxvyioyhpjvovw3kplp2ihnxi44
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeid3iodt57epbhi47w6kdorqovqjdc6jtqmeurmtzgnsuimh2ibiyi
+  tests/test_mech_info_behaviour.py: bafybeifrks6n275flc74hvgsncomomauzvyq54s36zt4yk2tiptuf6ez54
   tests/test_models.py: bafybeidzxsxhwwm2rbrgn5wpoyojk6jvtimfcycpbhnskg3ioz2swuqlmy
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
+- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
+- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeibdvq5vdanyhcdlb7pym4nftj5r7spznfb4pjibaj5uboq5koya74
+  behaviours/mech_info.py: bafybeih7xiaxbje24kybuf4mcthira3ocg4i6xuwpn2l2dlw5wxxvf52rm
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeignu6dmihcpn7ypbjtlv2z6mmo6uos2gkdn3m2bxydconalbdgkyu
   behaviours/request.py: bafybeic7rogh4ecofc36kymolnl6oxtqxvyioyhpjvovw3kplp2ihnxi44
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeic446q63ep3jvk3o2vxx6vpkhivqmeq7tncsgwuboqb4szdjg6g44
+  tests/test_mech_info_behaviour.py: bafybeiayjajfzmziihffr5a7yxq7rh7ie757xqeoeejtmy2wcmnbg7jpiq
   tests/test_models.py: bafybeidzxsxhwwm2rbrgn5wpoyojk6jvtimfcycpbhnskg3ioz2swuqlmy
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
+- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
+- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -324,6 +324,97 @@ class TestQuarantine:
         mock_api.reset_retries.assert_called_once()
         behaviour.context.logger.error.assert_called()
 
+    def test_populate_tools_does_not_quarantine_before_retries_exceeded(self) -> None:
+        """A single failure with retries not yet exceeded leaves _failed_mechs empty."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        mock_api.process_response.return_value = None
+        mock_api.is_retries_exceeded.return_value = False
+        mock_api.url = "http://test/broken-cid"
+        behaviour._context.mech_tools = mock_api
+
+        mech = _make_mech_info(address="0xtransient", relevant_tools=set())
+
+        def mock_get_http_response(**kwargs):
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        gen = behaviour.populate_tools([mech])
+        try:
+            next(gen)
+            gen.send(None)
+        except StopIteration as e:
+            result = e.value
+
+        assert result is False
+        assert behaviour._failed_mechs == set()
+        mock_api.increment_retries.assert_called_once()
+        mock_api.reset_retries.assert_not_called()
+
+    def test_quarantine_only_fires_on_final_retry(self) -> None:
+        """populate_tools is invoked multiple times; quarantine fires only when retries exhaust."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+
+        retries_limit = 3
+        call_count = {"n": 0}
+
+        def is_retries_exceeded_side_effect():
+            return call_count["n"] >= retries_limit
+
+        def increment_retries_side_effect():
+            call_count["n"] += 1
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        mock_api.process_response.return_value = None
+        mock_api.is_retries_exceeded.side_effect = is_retries_exceeded_side_effect
+        mock_api.increment_retries.side_effect = increment_retries_side_effect
+        mock_api.url = "http://test/broken-cid"
+        behaviour._context.mech_tools = mock_api
+
+        mech = _make_mech_info(address="0xflaky", relevant_tools=set())
+
+        def mock_get_http_response(**kwargs):
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        # Simulate get_mechs_info's outer while-loop: call populate_tools until True.
+        iterations = 0
+        while True:
+            iterations += 1
+            gen = behaviour.populate_tools([mech])
+            try:
+                next(gen)
+                gen.send(None)
+            except StopIteration as e:
+                outcome = e.value
+            if outcome:
+                break
+
+            # Before the final (quarantining) iteration, the mech must not yet
+            # be quarantined. This asserts the guard actually gates on the
+            # retries-exceeded flag, not just "first failure".
+            if iterations < retries_limit:
+                assert behaviour._failed_mechs == set()
+
+        assert (
+            iterations == retries_limit + 1
+        )  # N failures + 1 final pass returning True
+        assert "0xflaky" in behaviour._failed_mechs
+        assert mock_api.increment_retries.call_count == retries_limit
+
     def test_populate_tools_skips_quarantined_mechs(self) -> None:
         """A mech already in _failed_mechs is not fetched again."""
         behaviour = _make_mech_info_behaviour()

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -35,6 +35,7 @@ def _make_mech_info_behaviour(**overrides) -> MechInformationBehaviour:
     mock_context = MagicMock()
     behaviour._context = mock_context
     behaviour._fetch_status = FetchStatus.NONE
+    behaviour._failed_mechs = set()
 
     for key, value in overrides.items():
         setattr(behaviour, key, value)
@@ -145,6 +146,7 @@ class TestPopulateTools:
         mock_api.__dict__["_frozen"] = True
         mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
         mock_api.process_response.return_value = None  # failed
+        mock_api.is_retries_exceeded.return_value = False
         mock_api.url = "http://test/hash"
         behaviour._context.mech_tools = mock_api
 
@@ -281,3 +283,173 @@ class TestGetMechsInfo:
             result = e.value
 
         assert result is None
+
+
+class TestQuarantine:
+    """Tests for per-mech quarantine on IPFS fetch failure."""
+
+    def test_populate_tools_quarantines_mech_after_retries_exhausted(self) -> None:
+        """A mech whose fetch fails with retries exhausted is added to _failed_mechs."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        mock_api.process_response.return_value = None
+        mock_api.is_retries_exceeded.return_value = True
+        mock_api.url = "http://test/broken-cid"
+        behaviour._context.mech_tools = mock_api
+
+        mech = _make_mech_info(address="0xbroken", relevant_tools=set())
+
+        def mock_get_http_response(**kwargs):
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        gen = behaviour.populate_tools([mech])
+        try:
+            next(gen)
+            gen.send(None)
+        except StopIteration as e:
+            result = e.value
+
+        assert result is False
+        assert "0xbroken" in behaviour._failed_mechs
+        mock_api.reset_retries.assert_called_once()
+        behaviour.context.logger.error.assert_called()
+
+    def test_populate_tools_skips_quarantined_mechs(self) -> None:
+        """A mech already in _failed_mechs is not fetched again."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._failed_mechs = {"0xbroken"}
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        behaviour._context.mech_tools = mock_api
+
+        called = {"count": 0}
+
+        def mock_get_http_response(**kwargs):
+            called["count"] += 1
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        mech = _make_mech_info(address="0xbroken", relevant_tools=set())
+
+        gen = behaviour.populate_tools([mech])
+        try:
+            gen.send(None)
+        except StopIteration as e:
+            result = e.value
+
+        assert result is True
+        assert called["count"] == 0
+
+    def test_get_mechs_info_partial_success_returns_serialized_json(self) -> None:
+        """One good mech + one broken mech returns JSON with both; broken has empty tools."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._fetch_status = FetchStatus.SUCCESS
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.irrelevant_tools = set()
+
+        good = _make_mech_info(address="0xgood", relevant_tools=set())
+        broken = _make_mech_info(address="0xbroken", relevant_tools=set())
+
+        def mock_fetch_mechs_info():
+            behaviour._fetch_status = FetchStatus.SUCCESS
+            yield
+            return [good, broken]
+
+        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        # good -> tools list; broken -> None repeatedly until retries exceeded.
+        mock_api.process_response.side_effect = [["tool_good"], None]
+        mock_api.is_retries_exceeded.return_value = True
+        mock_api.url = "http://test/broken"
+        behaviour._context.mech_tools = mock_api
+
+        def mock_get_http_response(**kwargs):
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        gen = behaviour.get_mechs_info()
+        result = None
+        try:
+            while True:
+                next(gen)
+                gen.send(None)
+        except StopIteration as e:
+            result = e.value
+
+        assert result is not None
+        assert "0xgood" in result
+        assert "0xbroken" in result
+        assert good.relevant_tools == {"tool_good"}
+        assert broken.relevant_tools == set()
+        assert "0xbroken" in behaviour._failed_mechs
+
+    def test_get_mechs_info_all_failed_returns_none(self) -> None:
+        """If every mech fails, result is None so the round can retry."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._fetch_status = FetchStatus.SUCCESS
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+
+        mech = _make_mech_info(address="0xbroken", relevant_tools=set())
+
+        def mock_fetch_mechs_info():
+            behaviour._fetch_status = FetchStatus.SUCCESS
+            yield
+            return [mech]
+
+        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+
+        mock_api = MagicMock()
+        mock_api.__dict__["_frozen"] = True
+        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        mock_api.process_response.return_value = None
+        mock_api.is_retries_exceeded.return_value = True
+        mock_api.url = "http://test/broken"
+        behaviour._context.mech_tools = mock_api
+
+        def mock_get_http_response(**kwargs):
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        gen = behaviour.get_mechs_info()
+        result = "unset"
+        try:
+            while True:
+                next(gen)
+                gen.send(None)
+        except StopIteration as e:
+            result = e.value
+
+        assert result is None
+        assert "0xbroken" in behaviour._failed_mechs
+
+    def test_clean_up_clears_failed_mechs(self) -> None:
+        """clean_up resets the per-round quarantine set."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._failed_mechs = {"0xbroken"}
+        mock_api = MagicMock()
+        behaviour._context.mech_tools = mock_api
+
+        behaviour.clean_up()
+
+        assert behaviour._failed_mechs == set()
+        mock_api.reset_retries.assert_called_once()

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -169,8 +169,8 @@ class TestPopulateTools:
         mock_api.increment_retries.assert_called_once()
         behaviour.context.logger.warning.assert_called()
 
-    def test_warns_on_empty_tools(self) -> None:
-        """Test that empty tools list logs a warning but still succeeds."""
+    def test_quarantines_on_empty_tools(self) -> None:
+        """Empty tools list is deterministic per-CID; mech is quarantined."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
@@ -182,7 +182,7 @@ class TestPopulateTools:
         mock_api.process_response.return_value = []  # empty
         behaviour._context.mech_tools = mock_api
 
-        mech = _make_mech_info(relevant_tools=set())
+        mech = _make_mech_info(address="0xempty", relevant_tools=set())
 
         def mock_get_http_response(**kwargs):
             yield
@@ -198,9 +198,11 @@ class TestPopulateTools:
             result = e.value
 
         assert result is True
-        # Check the empty tools warning was logged
+        assert "0xempty" in behaviour._failed_mechs
+        assert mech.relevant_tools == set()
         warning_calls = behaviour.context.logger.warning.call_args_list
         assert any("empty" in str(call) for call in warning_calls)
+        mock_api.reset_retries.assert_called_once()
 
     def test_multiple_mechs_processes_all(self) -> None:
         """Test that populate_tools processes all mechs without existing tools."""


### PR DESCRIPTION
## Summary

- A single mech with a broken metadata CID (e.g. `0x33ca1e117c4254b2ee8cd7ef1621739431a37396` → CID `f01701220…` returning `protobuf: (PBNode) invalid wireType` from the IPFS gateway) previously caused `MechInformationRound` to return `None` on every attempt, cycling the FSM back to `MechVersionDetectionRound` indefinitely.
- `populate_tools` now quarantines individual mechs once the tools-manifest retries are exhausted, skips them on subsequent iterations, and lets the round complete with the remaining mechs.
- `get_mechs_info` only returns `None` when **every** mech has failed (so the FSM still retries cleanly rather than persisting an all-empty batch). A per-round `_failed_mechs` set is cleared in `clean_up`, so a republished CID is retried next time the round runs.
- Operators retain the existing `ignored_mechs` skill param as the permanent escape hatch for persistently broken mechs; the log now calls out quarantined addresses explicitly to make that signal easy to spot.

## Test plan

- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py -rfE` — 13 passed (5 new, 8 existing)
- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests -rfE` — 331 passed
- [x] `uv run tomte check-code` — black, isort, flake8, mypy, pylint, darglint all OK
- [x] `make generators` — skill hash updated in `packages.json` / `skill.yaml`
- [ ] Smoke test on mainnet: confirm logs show quarantine of `0x33ca1e11…` and the FSM advances past `MechInformationRound` instead of cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)