### PR TITLE
feat: parallelize populate_tools IPFS fetches

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiadirrijvit5zx7tyytgvyxud6onqqipvg5v6fvencg4aodunqune"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiebtvrpiizayjlck7irg4p7kdtvcpq27ixtjftnapweoztauf7rni"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeifr4tmupwcgi5xyftwpxtidjx3taadgmhdzxo32tnprdjqs3ddtje"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeidogdobxsahvndc5h3f7qfmm77mekijqqwwlj7dt2vvyu2z7uh3ve"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiftmk6vnaprnub4yegxxyllm3lai6od74ut7ppdnr3bidpqeukhka"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibfpco7zmnjjpavudwk2pd5lbn53omjnczxowpexsrvzfoa7xmw5y"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -28,10 +28,10 @@
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/agent_mech/0.1.0": "bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m",
-        "contract/valory/agent_registry/0.1.0": "bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi",
+        "contract/valory/agent_registry/0.1.0": "bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi",
         "contract/valory/service_registry/0.1.0": "bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e",
         "contract/valory/gnosis_safe/0.1.0": "bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y",
-        "contract/valory/erc20/0.1.0": "bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy",
+        "contract/valory/erc20/0.1.0": "bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiebtvrpiizayjlck7irg4p7kdtvcpq27ixtjftnapweoztauf7rni"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeifnwgjflfhagoomgqtnmlymlal5r23qcyesdyrhu5hyw7h6iqhqda"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeidogdobxsahvndc5h3f7qfmm77mekijqqwwlj7dt2vvyu2z7uh3ve"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiadirrijvit5zx7tyytgvyxud6onqqipvg5v6fvencg4aodunqune"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeihhrzm4rpfq54376hs5zft5g4mvqtv5hzzl67lpw7pgg3ja5dtmsu",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeif37we6t5hes72m2txc2upssmhynefhavkuvcqjkmvybqclophnnm",
         "contract/valory/subscription_provider/0.1.0": "bafybeiciopqd3vrqbmoq26ndnde5txdklpwyqioevfp2nu2mrdyjrjrfje",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibfpco7zmnjjpavudwk2pd5lbn53omjnczxowpexsrvzfoa7xmw5y"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeifr4tmupwcgi5xyftwpxtidjx3taadgmhdzxo32tnprdjqs3ddtje"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -28,10 +28,10 @@
         "contract/valory/multisend/0.1.0": "bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq",
         "contract/valory/agent_mech/0.1.0": "bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeieonbkuskzg2rwgbqwmouusnfdd4npow2pzasimetiebo3jhwjh7m",
-        "contract/valory/agent_registry/0.1.0": "bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi",
+        "contract/valory/agent_registry/0.1.0": "bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi",
         "contract/valory/service_registry/0.1.0": "bafybeigefenwg3lj4nvwc3cs5zxyhv4nvwnwbw5x7afwyijkjbbgbf2l7e",
         "contract/valory/gnosis_safe/0.1.0": "bafybeice337zvg3ol4cwpw2iikxcukmthwmw32ytwtdnkcju222qfc323y",
-        "contract/valory/erc20/0.1.0": "bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu",
+        "contract/valory/erc20/0.1.0": "bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/ledger/0.19.0": "bafybeid5uwx4uqxkiibw6kazr7my5mk5kcqg2dx2owtcf7kcpbs2jrns2e",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -21,8 +21,12 @@
 """This module contains the behaviour responsible for gathering information about the mech marketplace."""
 
 import json
-from typing import Any, Generator, Optional, Set
+import time
+from typing import Any, Callable, Dict, Generator, List, Optional, Set
 
+from aea.protocols.base import Message
+
+from packages.valory.protocols.http import HttpMessage
 from packages.valory.skills.mech_interact_abci.behaviours.base import (
     MechInteractBaseBehaviour,
     WaitableConditionType,
@@ -43,6 +47,25 @@ from packages.valory.skills.mech_interact_abci.states.mech_info import (
 )
 
 CID_PREFIX = "f01701220"
+PARALLEL_FETCH_POLL_INTERVAL = 0.1
+
+
+def _make_parallel_fetch_callback(
+    results: Dict[str, Optional[HttpMessage]], nonce: str
+) -> Callable[[Message, Any], None]:
+    """Build a nonce-scoped callback that stores the response in results.
+
+    Stays behaviour-state-agnostic so it dispatches regardless of whether the
+    owning behaviour is in WAITING_MESSAGE state (we aren't — we poll via
+    self.sleep while the fetch is in flight).
+    """
+
+    def _callback(message: Message, current_behaviour: Any) -> None:
+        # The mech_interact parallel fetcher only ever receives HttpMessage
+        # responses for these nonces; the cast is safe by construction.
+        results[nonce] = message  # type: ignore[assignment]
+
+    return _callback
 
 
 class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
@@ -55,6 +78,8 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         super().__init__(**kwargs)
         self._fetch_status: FetchStatus = FetchStatus.NONE
         self._failed_mechs: Set[str] = set()
+        # Injectable clock for deterministic parallel-fetch timeout tests.
+        self._clock: Callable[[], float] = time.monotonic
 
     @property
     def mech_tools_api(self) -> MechToolsSpecs:  # pragma: no cover
@@ -68,6 +93,45 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         self.mech_tools_api.__dict__["_frozen"] = False
         self.mech_tools_api.url = ipfs_link
         self.mech_tools_api.__dict__["_frozen"] = True
+
+    def _fetch_http_parallel(
+        self,
+        specs: List[Dict[str, Any]],
+        timeout: float,
+        poll_interval: float = PARALLEL_FETCH_POLL_INTERVAL,
+    ) -> Generator[None, None, List[Optional[HttpMessage]]]:
+        """Fire N HTTP requests concurrently; return responses in input order.
+
+        :param specs: list of kwargs dicts for _build_http_request_message.
+        :param timeout: wall-clock budget (via self._clock) for the whole batch.
+        :param poll_interval: sleep between readiness checks.
+        :return: list with one entry per input spec; None for timed-out
+            requests. Unresolved callbacks are popped from the request
+            registry on exit.
+        :yield: None while awaiting responses.
+        """
+        results: Dict[str, Optional[HttpMessage]] = {}
+        nonces: List[str] = []
+        registry = self.context.requests.request_id_to_callback
+
+        for spec in specs:
+            message, dialogue = self._build_http_request_message(**spec)
+            nonce = self._get_request_nonce_from_dialogue(dialogue)
+            nonces.append(nonce)
+            registry[nonce] = _make_parallel_fetch_callback(results, nonce)
+            self.context.outbox.put_message(message=message)
+
+        deadline = self._clock() + timeout
+        try:
+            while len(results) < len(nonces):
+                if self._clock() >= deadline:
+                    break
+                yield from self.sleep(poll_interval)
+        finally:
+            for nonce in nonces:
+                registry.pop(nonce, None)
+
+        return [results.get(n) for n in nonces]
 
     def populate_tools(
         self, mech_info: MechsSubgraphResponseType

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -136,20 +136,44 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
     def populate_tools(
         self, mech_info: MechsSubgraphResponseType
     ) -> WaitableConditionType:
-        """Populate the tools of the mech info, using the metadata."""
-        for mech in mech_info:
-            if mech.relevant_tools or mech.address in self._failed_mechs:
+        """Populate the tools of the mech info, using the metadata, in parallel."""
+        pending = [
+            mech
+            for mech in mech_info
+            if not mech.relevant_tools and mech.address not in self._failed_mechs
+        ]
+        if not pending:
+            return True
+
+        specs_per_mech: List[Dict[str, Any]] = []
+        for mech in pending:
+            # set_mech_agent_specs mutates mech_tools_api.url. Snapshot
+            # get_spec() BEFORE advancing to the next mech so each sent
+            # request carries its own mech's CID.
+            self.set_mech_agent_specs(mech.service.metadata_str)
+            specs_per_mech.append(dict(self.mech_tools_api.get_spec()))
+
+        responses = yield from self._fetch_http_parallel(
+            specs_per_mech,
+            timeout=self.params.mech_tools_parallel_timeout,
+        )
+
+        any_transient = False
+        for mech, res_raw in zip(pending, responses):
+            if res_raw is None:
+                self.context.logger.warning(
+                    f"Timed out fetching {mech.address} mech agent's tools."
+                )
+                any_transient = True
                 continue
 
-            self.set_mech_agent_specs(mech.service.metadata_str)
-            specs = self.mech_tools_api.get_spec()
-            res_raw = yield from self.get_http_response(**specs)
             res = self.mech_tools_api.process_response(res_raw)
 
             if res is None:
-                msg = f"Could not get the {mech.address} mech agent's tools from {self.mech_tools_api.url}."
-                self.context.logger.warning(msg)
-
+                self.context.logger.warning(
+                    f"Could not get the {mech.address} mech agent's tools "
+                    f"from {self.mech_tools_api.url}."
+                )
                 if self.mech_tools_api.is_permanent_error(res_raw):
                     self.context.logger.error(
                         f"Quarantining mech {mech.address}: permanent content "
@@ -157,19 +181,9 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                         f"(status={res_raw.status_code}); retries skipped."
                     )
                     self._failed_mechs.add(mech.address)
-                    self.mech_tools_api.reset_retries()
-                    return False
-
-                self.mech_tools_api.increment_retries()
-                if self.mech_tools_api.is_retries_exceeded():
-                    self.context.logger.error(
-                        f"Quarantining mech {mech.address}: could not fetch "
-                        f"tools manifest from {self.mech_tools_api.url} "
-                        f"after retries exhausted."
-                    )
-                    self._failed_mechs.add(mech.address)
-                    self.mech_tools_api.reset_retries()
-                return False
+                else:
+                    any_transient = True
+                continue
 
             if len(res) == 0:
                 self.context.logger.warning(
@@ -178,15 +192,34 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                     f"deterministic per-CID; will retry on next round entry."
                 )
                 self._failed_mechs.add(mech.address)
-                self.mech_tools_api.reset_retries()
                 continue
 
-            # store only the relevant mech tools
             relevant_tools = set(res) - self.params.irrelevant_tools
             mech.relevant_tools |= relevant_tools
+
+        # Advance the shared retry counter once per pass that had transient
+        # failures. On exhaustion, quarantine every still-unpopulated mech.
+        if any_transient:
+            self.mech_tools_api.increment_retries()
+            if self.mech_tools_api.is_retries_exceeded():
+                for mech in pending:
+                    if (
+                        not mech.relevant_tools
+                        and mech.address not in self._failed_mechs
+                    ):
+                        self.context.logger.error(
+                            f"Quarantining mech {mech.address}: retries "
+                            f"exhausted after transient failures."
+                        )
+                        self._failed_mechs.add(mech.address)
+                self.mech_tools_api.reset_retries()
+        else:
             self.mech_tools_api.reset_retries()
 
-        return True
+        return all(
+            mech.relevant_tools or mech.address in self._failed_mechs
+            for mech in pending
+        )
 
     def get_mechs_info(
         self,

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -125,6 +125,19 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         nonces: List[str] = []
         registry = self.context.requests.request_id_to_callback
 
+        # This primitive relies on three BaseBehaviour / skill-context
+        # invariants. If any of them changes, the parallel path breaks
+        # silently and should be reworked rather than patched:
+        #   1. context.requests.request_id_to_callback is a nonce-keyed dict
+        #      the HTTP response handler consults to dispatch incoming
+        #      messages — we register callbacks directly against it.
+        #   2. context.outbox.put_message is non-blocking (the multiplexer
+        #      schedules the envelope asynchronously), so the fan-out loop
+        #      can send N messages before yielding even once.
+        #   3. The response handler dispatches by dialogue nonce, not by
+        #      behaviour state — this behaviour stays in RUNNING and polls
+        #      via self.sleep, and still receives responses via the
+        #      registered callbacks.
         try:
             # Registration is inside the try so any framework-method raise
             # mid-fan-out still triggers the finally-block cleanup of the
@@ -158,6 +171,10 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
             if not mech.relevant_tools and mech.address not in self._failed_mechs
         ]
         if not pending:
+            # Symmetric with the end-of-pass reset below: every exit path
+            # from populate_tools leaves the shared retry counter at zero,
+            # so future refactors can rely on that invariant.
+            self.mech_tools_api.reset_retries()
             return True
 
         specs_per_mech: List[Dict[str, Any]] = []

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -276,6 +276,9 @@ class MechParams(BaseParams):
             "use_acn_for_delivers", kwargs, bool
         )
         self.irrelevant_tools: set = set(self._ensure("irrelevant_tools", kwargs, list))
+        self.mech_tools_parallel_timeout: float = self._ensure(
+            "mech_tools_parallel_timeout", kwargs, float
+        )
         self.ignored_mechs: FrozenSet[str] = frozenset(
             self._ensure("ignored_mechs", kwargs, List[str])
         )

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -276,8 +276,10 @@ class MechParams(BaseParams):
             "use_acn_for_delivers", kwargs, bool
         )
         self.irrelevant_tools: set = set(self._ensure("irrelevant_tools", kwargs, list))
-        self.mech_tools_parallel_timeout: float = self._ensure(
-            "mech_tools_parallel_timeout", kwargs, float
+        # Optional with a safe default: downstream skills inheriting MechParams
+        # don't need to touch their skill.yaml to pick up this fix.
+        self.mech_tools_parallel_timeout: float = float(
+            kwargs.get("mech_tools_parallel_timeout", 20.0)
         )
         self.ignored_mechs: FrozenSet[str] = frozenset(
             self._ensure("ignored_mechs", kwargs, List[str])

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
+- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
+- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeie3glmx2hwtmeleudznkb3c6cjpvbhqslvp22nndx5uqz6gx2mwo4
+  behaviours/mech_info.py: bafybeigboahol6ipwxumkvjpt6bzwhh7mxtcxd5qbvpvpxq2qi7gdn6nua
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeignu6dmihcpn7ypbjtlv2z6mmo6uos2gkdn3m2bxydconalbdgkyu
   behaviours/request.py: bafybeic7rogh4ecofc36kymolnl6oxtqxvyioyhpjvovw3kplp2ihnxi44
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeigmk3y3uwlsmzommqwimirko6vph3j6mmymxbncshjdzebne4nija
   graph_tooling/requests.py: bafybeieebeky62sm2fzqy5egbg4fk5cbi2loywgl6x5dbfraatygmlqe4m
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeibcymkncmcom7actkhz6agwbbtjnwiell733lve4m6nt4bqxzstnu
+  models.py: bafybeiew5ul7qhwretunz6nmzhzhjyxdb4l5rmwbpmlj7lttplgklyspee
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeiewhynivpu72vzstzppmqedoytidmfgjszf7mb22ml7lhi5ep6eyy
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeiezfv2paan5vet5rl6ztmesxsxon2bj3ybcjecbskpnq7gzrvfybm
+  tests/test_mech_info_behaviour.py: bafybeicsgdz6gd3pptmjtr3ak2pk7cebj2gu2qgupyeknscugvh2itfuom
   tests/test_models.py: bafybeialgu2mdr4uba5m25x4xo4so6r2divklqiqmdokvk62ilxvmfwn64
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeihquknpac6bgrj5dhynjqnmnugzg6tq72hmj3rxnmgz5ohbirpqj4
 - valory/mech_mm:0.1.0:bafybeidglyk3ceukmrrfh2abi25ypqhycet4ihlsjigilrv7j6pnt4aroy
 - valory/multisend:0.1.0:bafybeihx7c3xj6c5v4tgvu3ipnj7seyc4dkmovoyzu4isgbwdrhj2oo6uq
-- valory/erc20:0.1.0:bafybeifq6zn2p5nafi6bmtf4xo3ctgymazr2udtlwyiwjf5g5mpndsthfy
+- valory/erc20:0.1.0:bafybeidzxzfkv4ttg6o3vyymd5u3jgqmomblkzh4sk6g5moscta5cikufu
 - valory/agent_mech:0.1.0:bafybeielgw42wh6sucnquowlqqf3dbvzd7gj4r6vfn322t3i5pkxbbrwz4
 - valory/mech_marketplace_legacy:0.1.0:bafybeifbrb6zdwon7a4rfdzypy5sjepbx7iyebebhaq5ydx2kdcbmdnba4
-- valory/agent_registry:0.1.0:bafybeifhwzocl6itefynfm4epcw6xhu7k3vnasx6tmfg4k7xv7hmsykgwi
+- valory/agent_registry:0.1.0:bafybeihid7crlp5yhivs2spf7shmxihchla3mozvq2yuopba34f3omwsqi
 - valory/ierc1155:0.1.0:bafybeicculy2cfhvcrz3n5j6zadkro7ylbvitetlda3pkufkcf65cs2uty
 - valory/nvm_balance_tracker_token:0.1.0:bafybeibte5igiqmq77ddx4mojqyvma4wuutqru3d7rrbopm6tkdp737iyq
 - valory/nvm_balance_tracker_native:0.1.0:bafybeifcpdhuq7pgt2ok544q7tlqw3sitrh3yspmfog7ofhernnouwebfe
@@ -224,6 +224,7 @@ models:
       - stabilityai-stable-diffusion-768-v2-1
       deliveries_lookback_days: 30
       ignored_mechs: []
+      mech_tools_parallel_timeout: 20.0
       penalize_mech_time_window: 1800
     class_name: Params
   mech_tools:

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeigboahol6ipwxumkvjpt6bzwhh7mxtcxd5qbvpvpxq2qi7gdn6nua
+  behaviours/mech_info.py: bafybeie2ztq2xjkoea6vufkrx5ij4cnzbn32ievhjqcpol2omhsizhsmna
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeignu6dmihcpn7ypbjtlv2z6mmo6uos2gkdn3m2bxydconalbdgkyu
   behaviours/request.py: bafybeic7rogh4ecofc36kymolnl6oxtqxvyioyhpjvovw3kplp2ihnxi44
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeigmk3y3uwlsmzommqwimirko6vph3j6mmymxbncshjdzebne4nija
   graph_tooling/requests.py: bafybeieebeky62sm2fzqy5egbg4fk5cbi2loywgl6x5dbfraatygmlqe4m
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeih7xpmn2j2t3pimcnwwq2tpnygrsdhg43qi2q2fe5z5mj7hivehgy
+  models.py: bafybeiag3iwtsjoxxjb4khtw3mzpehvsq7wxkcbjpqxrf2tttuqxobsjlq
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeiewhynivpu72vzstzppmqedoytidmfgjszf7mb22ml7lhi5ep6eyy
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
@@ -51,8 +51,8 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeiglo24r7ppfmi4ygbyen5famnw3z7pp45l7bbiguq66fadliplfle
-  tests/test_models.py: bafybeialgu2mdr4uba5m25x4xo4so6r2divklqiqmdokvk62ilxvmfwn64
+  tests/test_mech_info_behaviour.py: bafybeificwrmpvyrakbnhuwzlecaml3i4xqoeehhnls6hm7cchh5hlwsaa
+  tests/test_models.py: bafybeiccfqlggxe7fiwxwbae2uuw53ezepdsgjhl5vglnes5uv4c3px54i
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
   tests/test_response_behaviour.py: bafybeihzlqndt5qxpl6pwvdbsutpupvcbinf3mrvm5bgstaqhqxx5yicha

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeigmk3y3uwlsmzommqwimirko6vph3j6mmymxbncshjdzebne4nija
   graph_tooling/requests.py: bafybeieebeky62sm2fzqy5egbg4fk5cbi2loywgl6x5dbfraatygmlqe4m
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeiew5ul7qhwretunz6nmzhzhjyxdb4l5rmwbpmlj7lttplgklyspee
+  models.py: bafybeih7xpmn2j2t3pimcnwwq2tpnygrsdhg43qi2q2fe5z5mj7hivehgy
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeiewhynivpu72vzstzppmqedoytidmfgjszf7mb22ml7lhi5ep6eyy
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeicsgdz6gd3pptmjtr3ak2pk7cebj2gu2qgupyeknscugvh2itfuom
+  tests/test_mech_info_behaviour.py: bafybeiglo24r7ppfmi4ygbyen5famnw3z7pp45l7bbiguq66fadliplfle
   tests/test_models.py: bafybeialgu2mdr4uba5m25x4xo4so6r2divklqiqmdokvk62ilxvmfwn64
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeie2ztq2xjkoea6vufkrx5ij4cnzbn32ievhjqcpol2omhsizhsmna
+  behaviours/mech_info.py: bafybeiexut5veu2s2qr6mvlauijwkfcskzvdekjltwkbdl7ixkuf5m657y
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeignu6dmihcpn7ypbjtlv2z6mmo6uos2gkdn3m2bxydconalbdgkyu
   behaviours/request.py: bafybeic7rogh4ecofc36kymolnl6oxtqxvyioyhpjvovw3kplp2ihnxi44

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -66,6 +66,21 @@ def _wire_parallel_fetch(
     return behaviour
 
 
+def _install_fake_parallel_fetch(behaviour, responses):
+    """Replace behaviour._fetch_http_parallel with a generator returning responses.
+
+    Each element of `responses` maps 1:1 to a pending mech in populate_tools.
+    A value of None represents a timed-out request.
+    """
+
+    def _fake_fetch(specs, timeout, poll_interval=0.1):
+        yield
+        return list(responses)
+
+    behaviour._fetch_http_parallel = _fake_fetch
+    return behaviour
+
+
 def _make_mech_info(
     address: str = "0xmech1",
     metadata_str: str = "abc123",
@@ -130,6 +145,7 @@ class TestPopulateTools:
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
         behaviour._context.params.irrelevant_tools = {"irrelevant_tool"}
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -138,22 +154,9 @@ class TestPopulateTools:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        # Mock get_http_response as a generator
-        http_response = MagicMock()
-
-        def mock_get_http_response(**kwargs):
-            yield
-            return http_response
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)  # yield from get_http_response
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is True
         assert mech.relevant_tools == {"tool_a", "tool_b"}
@@ -164,6 +167,7 @@ class TestPopulateTools:
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -175,19 +179,9 @@ class TestPopulateTools:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is False
         mock_api.increment_retries.assert_called_once()
@@ -199,6 +193,7 @@ class TestPopulateTools:
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
         behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -207,19 +202,9 @@ class TestPopulateTools:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(address="0xempty", relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is True
         assert "0xempty" in behaviour._failed_mechs
@@ -229,37 +214,24 @@ class TestPopulateTools:
         mock_api.reset_retries.assert_called_once()
 
     def test_multiple_mechs_processes_all(self) -> None:
-        """Test that populate_tools processes all mechs without existing tools."""
+        """Test that populate_tools processes all mechs in parallel in one pass."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
         behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
         mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        # Return different tools for each call
         mock_api.process_response.side_effect = [["tool_1"], ["tool_2"]]
         behaviour._context.mech_tools = mock_api
 
         mech1 = _make_mech_info(address="0xmech1", relevant_tools=set())
         mech2 = _make_mech_info(address="0xmech2", relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock(), MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech1, mech2])
-        try:
-            next(gen)  # first mech: yield from get_http_response
-            gen.send(
-                None
-            )  # first mech completes, second mech: yield from get_http_response
-            gen.send(None)  # second mech completes, generator returns True
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech1, mech2]))
 
         assert result is True
         assert mech1.relevant_tools == {"tool_1"}
@@ -315,10 +287,11 @@ class TestQuarantine:
     """Tests for per-mech quarantine on IPFS fetch failure."""
 
     def test_populate_tools_quarantines_mech_after_retries_exhausted(self) -> None:
-        """A mech whose fetch fails with retries exhausted is added to _failed_mechs."""
+        """A transient mech whose retries are exhausted is added to _failed_mechs."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -330,30 +303,21 @@ class TestQuarantine:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(address="0xbroken", relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
+        result = _drive(behaviour.populate_tools([mech]))
 
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
-
-        assert result is False
+        assert result is True  # mech now quarantined, no more work
         assert "0xbroken" in behaviour._failed_mechs
         mock_api.reset_retries.assert_called_once()
         behaviour.context.logger.error.assert_called()
 
     def test_populate_tools_does_not_quarantine_before_retries_exceeded(self) -> None:
-        """A single failure with retries not yet exceeded leaves _failed_mechs empty."""
+        """Transient failure with retries remaining leaves _failed_mechs empty."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -365,19 +329,9 @@ class TestQuarantine:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(address="0xtransient", relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is False
         assert behaviour._failed_mechs == set()
@@ -385,10 +339,11 @@ class TestQuarantine:
         mock_api.reset_retries.assert_not_called()
 
     def test_quarantine_only_fires_on_final_retry(self) -> None:
-        """populate_tools is invoked multiple times; quarantine fires only when retries exhaust."""
+        """Across N passes, retry counter advances once per pass; quarantine only on exhaustion."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         retries_limit = 3
         call_count = {"n": 0}
@@ -411,34 +366,21 @@ class TestQuarantine:
 
         mech = _make_mech_info(address="0xflaky", relevant_tools=set())
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        # Simulate get_mechs_info's outer while-loop: call populate_tools until True.
+        # Each populate_tools pass sees one transient failure.
+        # The fake is re-used across passes.
         iterations = 0
         while True:
             iterations += 1
-            gen = behaviour.populate_tools([mech])
-            try:
-                next(gen)
-                gen.send(None)
-            except StopIteration as e:
-                outcome = e.value
+            _install_fake_parallel_fetch(behaviour, [MagicMock()])
+            outcome = _drive(behaviour.populate_tools([mech]))
             if outcome:
                 break
-
-            # Before the final (quarantining) iteration, the mech must not yet
-            # be quarantined. This asserts the guard actually gates on the
-            # retries-exceeded flag, not just "first failure".
             if iterations < retries_limit:
                 assert behaviour._failed_mechs == set()
 
-        assert (
-            iterations == retries_limit + 1
-        )  # N failures + 1 final pass returning True
+        # Quarantine fires on the pass that exhausts retries (same iteration
+        # as the Nth increment), so we expect exactly retries_limit passes.
+        assert iterations == retries_limit
         assert "0xflaky" in behaviour._failed_mechs
         assert mock_api.increment_retries.call_count == retries_limit
 
@@ -478,6 +420,7 @@ class TestQuarantine:
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
         behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         good = _make_mech_info(address="0xgood", relevant_tools=set())
         broken = _make_mech_info(address="0xbroken", relevant_tools=set())
@@ -492,27 +435,14 @@ class TestQuarantine:
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
         mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        # good -> tools list; broken -> None repeatedly until retries exceeded.
         mock_api.process_response.side_effect = [["tool_good"], None]
         mock_api.is_retries_exceeded.return_value = True
         mock_api.is_permanent_error.return_value = False
         mock_api.url = "http://test/broken"
         behaviour._context.mech_tools = mock_api
+        _install_fake_parallel_fetch(behaviour, [MagicMock(), MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.get_mechs_info()
-        result = None
-        try:
-            while True:
-                next(gen)
-                gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.get_mechs_info())
 
         assert result is not None
         assert "0xgood" in result
@@ -527,6 +457,7 @@ class TestQuarantine:
         behaviour._fetch_status = FetchStatus.SUCCESS
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mech = _make_mech_info(address="0xbroken", relevant_tools=set())
 
@@ -545,21 +476,9 @@ class TestQuarantine:
         mock_api.is_permanent_error.return_value = False
         mock_api.url = "http://test/broken"
         behaviour._context.mech_tools = mock_api
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.get_mechs_info()
-        result = "unset"
-        try:
-            while True:
-                next(gen)
-                gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.get_mechs_info())
 
         assert result is None
         assert "0xbroken" in behaviour._failed_mechs
@@ -585,6 +504,7 @@ class TestPermanentErrorClassification:
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -598,37 +518,26 @@ class TestPermanentErrorClassification:
 
         http_message = MagicMock()
         http_message.status_code = 500
+        _install_fake_parallel_fetch(behaviour, [http_message])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return http_message
+        result = _drive(behaviour.populate_tools([mech]))
 
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
-
-        assert result is False
+        assert result is True  # quarantined; nothing more to do
         assert "0xpermanent" in behaviour._failed_mechs
         mock_api.increment_retries.assert_not_called()
         mock_api.reset_retries.assert_called_once()
-        # Classifier was invoked on the received response.
         mock_api.is_permanent_error.assert_called_once_with(http_message)
-        # Error log mentions permanent content error for ops telemetry.
         error_calls = behaviour.context.logger.error.call_args_list
         assert any("permanent content error" in str(call) for call in error_calls)
 
     def test_transient_error_still_increments_retries_and_does_not_quarantine(
         self,
     ) -> None:
-        """Transient path is byte-identical to pre-Fix-2 behaviour."""
+        """Transient path keeps the existing retry semantics."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
@@ -640,19 +549,9 @@ class TestPermanentErrorClassification:
         behaviour._context.mech_tools = mock_api
 
         mech = _make_mech_info(address="0xtransient", relevant_tools=set())
+        _install_fake_parallel_fetch(behaviour, [MagicMock()])
 
-        def mock_get_http_response(**kwargs):
-            yield
-            return MagicMock()
-
-        behaviour.get_http_response = mock_get_http_response
-
-        gen = behaviour.populate_tools([mech])
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is False
         assert behaviour._failed_mechs == set()
@@ -660,16 +559,20 @@ class TestPermanentErrorClassification:
         mock_api.reset_retries.assert_not_called()
 
     def test_get_mechs_info_permanent_error_needs_only_one_http_call(self) -> None:
-        """End-to-end: permanent broken mech quarantined on first attempt.
+        """Permanent broken mech quarantined on first attempt.
 
-        Before Fix 2 the broken mech would consume `retries+1` HTTP calls
-        (6 attempts) before quarantine. After Fix 2 it takes exactly 1.
+        Before Fix 2 the broken mech would consume 6 attempts before
+        quarantine. Fix 2 made it 1 attempt. Fix 4 (this change) runs
+        the good + broken fetches in parallel, so total wall time =
+        max(per-mech) instead of sum. Asserts one parallel pass, two
+        HTTP sends.
         """
         behaviour = _make_mech_info_behaviour()
         behaviour._fetch_status = FetchStatus.SUCCESS
         behaviour._context.params = MagicMock()
         behaviour._context.params.ipfs_address = "https://ipfs.io/"
         behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
 
         good = _make_mech_info(address="0xgood", relevant_tools=set())
         broken = _make_mech_info(address="0xbroken", relevant_tools=set())
@@ -681,9 +584,6 @@ class TestPermanentErrorClassification:
 
         behaviour.fetch_mechs_info = mock_fetch_mechs_info
 
-        # Order the good mech first so it's populated before the broken one
-        # triggers the return-False path. Broken then gets classified on its
-        # first attempt.
         mock_api = MagicMock()
         mock_api.__dict__["_frozen"] = True
         mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
@@ -692,23 +592,19 @@ class TestPermanentErrorClassification:
         mock_api.url = "http://test/broken"
         behaviour._context.mech_tools = mock_api
 
-        http_call_count = {"n": 0}
+        parallel_call_count = {"n": 0}
+        total_requests = {"n": 0}
 
-        def mock_get_http_response(**kwargs):
-            http_call_count["n"] += 1
+        def _fake_fetch(specs, timeout, poll_interval=0.1):
+            parallel_call_count["n"] += 1
+            total_requests["n"] += len(specs)
             yield
-            return MagicMock()
+            # good first, broken second (per pending order)
+            return [MagicMock(), MagicMock()]
 
-        behaviour.get_http_response = mock_get_http_response
+        behaviour._fetch_http_parallel = _fake_fetch
 
-        gen = behaviour.get_mechs_info()
-        result = None
-        try:
-            while True:
-                next(gen)
-                gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.get_mechs_info())
 
         assert result is not None
         assert "0xgood" in result
@@ -716,9 +612,9 @@ class TestPermanentErrorClassification:
         assert good.relevant_tools == {"tool_good"}
         assert broken.relevant_tools == set()
         assert "0xbroken" in behaviour._failed_mechs
-        # Key assertion: exactly 2 HTTP calls — 1 good + 1 permanent broken.
-        # Pre-Fix-2 this would be 7 (1 good + 6 broken retries).
-        assert http_call_count["n"] == 2
+        # One parallel pass, two total HTTP sends (one per mech).
+        assert parallel_call_count["n"] == 1
+        assert total_requests["n"] == 2
         mock_api.increment_retries.assert_not_called()
 
 
@@ -783,7 +679,11 @@ class TestFetchHttpParallel:
         self._install_counting_sleep(behaviour)
 
         gen = behaviour._fetch_http_parallel(
-            [{"method": "GET", "url": "u1"}, {"method": "GET", "url": "u2"}, {"method": "GET", "url": "u3"}],
+            [
+                {"method": "GET", "url": "u1"},
+                {"method": "GET", "url": "u2"},
+                {"method": "GET", "url": "u3"},
+            ],
             timeout=10.0,
         )
         # Drive just to the first yield (first sleep call).
@@ -807,7 +707,11 @@ class TestFetchHttpParallel:
         )
         _step(gen)  # fan-out done; first sleep yielded
 
-        msg1, msg2, msg3 = MagicMock(name="m1"), MagicMock(name="m2"), MagicMock(name="m3")
+        msg1, msg2, msg3 = (
+            MagicMock(name="m1"),
+            MagicMock(name="m2"),
+            MagicMock(name="m3"),
+        )
         # Fire in reverse arrival order.
         registry["n2"](msg2, behaviour)
         registry["n3"](msg3, behaviour)
@@ -898,3 +802,181 @@ class TestFetchHttpParallel:
         # No calls of any kind on current_behaviour — not try_send, not state.
         mock_current_behaviour.assert_not_called()
         assert not mock_current_behaviour.method_calls
+
+
+class TestPopulateToolsParallelSemantics:
+    """Tests for the parallel-batch semantics of populate_tools (Fix 4)."""
+
+    def _setup(self, behaviour, api_side_effects=None):
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
+        api = MagicMock()
+        api.__dict__["_frozen"] = True
+        api.get_spec.return_value = {"url": "http://test", "method": "GET"}
+        api.url = "http://test/hash"
+        if api_side_effects is not None:
+            api.process_response.side_effect = api_side_effects
+        behaviour._context.mech_tools = api
+        return api
+
+    def test_mixed_permanent_transient_good_in_one_batch(self) -> None:
+        """B3: three mechs with different outcomes; all handled in one pass."""
+        behaviour = _make_mech_info_behaviour()
+        api = self._setup(behaviour, api_side_effects=[["tool_x"], None, None])
+        api.is_permanent_error.side_effect = [
+            True,
+            False,
+        ]  # order: permanent, transient
+        api.is_retries_exceeded.return_value = False
+
+        mech_good = _make_mech_info(
+            address="0xgood", metadata_str="good", relevant_tools=set()
+        )
+        mech_permanent = _make_mech_info(
+            address="0xpermanent", metadata_str="permanent", relevant_tools=set()
+        )
+        mech_transient = _make_mech_info(
+            address="0xtransient", metadata_str="transient", relevant_tools=set()
+        )
+
+        perm_response = MagicMock()
+        perm_response.status_code = 500
+        _install_fake_parallel_fetch(
+            behaviour, [MagicMock(), perm_response, MagicMock()]
+        )
+
+        result = _drive(
+            behaviour.populate_tools([mech_good, mech_permanent, mech_transient])
+        )
+
+        assert result is False  # transient still has retries
+        assert mech_good.relevant_tools == {"tool_x"}
+        assert "0xpermanent" in behaviour._failed_mechs
+        assert "0xtransient" not in behaviour._failed_mechs
+        # Single increment for the batch, not per-mech.
+        api.increment_retries.assert_called_once()
+
+    def test_all_transient_batch_advances_shared_counter_once(self) -> None:
+        """B4: shared retry counter advances once per pass, not per mech."""
+        behaviour = _make_mech_info_behaviour()
+        api = self._setup(behaviour, api_side_effects=[None, None, None])
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = False
+
+        mechs = [
+            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
+            for i in range(3)
+        ]
+        _install_fake_parallel_fetch(behaviour, [MagicMock()] * 3)
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is False
+        assert behaviour._failed_mechs == set()
+        # Three transient failures in one pass -> ONE counter advance, not three.
+        assert api.increment_retries.call_count == 1
+
+    def test_retries_exhausted_during_batch_quarantines_all_pending(self) -> None:
+        """B5: on retries exhaustion, quarantine every still-unpopulated mech."""
+        behaviour = _make_mech_info_behaviour()
+        api = self._setup(behaviour, api_side_effects=[None, None, None])
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = True
+
+        mechs = [
+            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
+            for i in range(3)
+        ]
+        _install_fake_parallel_fetch(behaviour, [MagicMock()] * 3)
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is True  # every mech quarantined; no more work
+        for i in range(3):
+            assert f"0x{i}" in behaviour._failed_mechs
+        api.reset_retries.assert_called_once()
+
+    def test_timed_out_fetch_is_treated_as_transient(self) -> None:
+        """B6: None response (timeout) increments retries; no quarantine."""
+        behaviour = _make_mech_info_behaviour()
+        api = self._setup(behaviour)
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = False
+
+        mechs = [
+            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
+            for i in range(3)
+        ]
+        _install_fake_parallel_fetch(behaviour, [None, None, None])
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is False
+        assert behaviour._failed_mechs == set()
+        api.increment_retries.assert_called_once()
+
+    def test_zero_pending_mechs_returns_true_without_fetching(self) -> None:
+        """B2: all mechs pre-populated — no fetch, no put_message."""
+        behaviour = _make_mech_info_behaviour()
+        self._setup(behaviour)
+
+        mechs = [
+            _make_mech_info(address="0xm1", relevant_tools={"already"}),
+            _make_mech_info(address="0xm2", relevant_tools={"here"}),
+        ]
+
+        fetch_calls = []
+
+        def _fake_fetch(specs, timeout, poll_interval=0.1):
+            fetch_calls.append(specs)
+            yield
+            return [MagicMock() for _ in specs]
+
+        behaviour._fetch_http_parallel = _fake_fetch
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is True
+        assert fetch_calls == []
+
+    def test_specs_snapshotted_per_mech(self) -> None:
+        """B1: each mech's spec is snapshotted before the next mech's URL mutation."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._context.params = MagicMock()
+        behaviour._context.params.ipfs_address = "https://ipfs.io/"
+        behaviour._context.params.irrelevant_tools = set()
+        behaviour._context.params.mech_tools_parallel_timeout = 10.0
+
+        # Real ApiSpecs-style url mutation via set_mech_agent_specs.
+        api = MagicMock()
+        api.__dict__["_frozen"] = True
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = False
+        api.process_response.side_effect = [["tool_a"], ["tool_b"]]
+        # get_spec returns the current URL at the time of the call.
+        api.get_spec = lambda: {"url": api.url, "method": "GET"}
+        behaviour._context.mech_tools = api
+
+        mech_a = _make_mech_info(
+            address="0xa", metadata_str="aaa", relevant_tools=set()
+        )
+        mech_b = _make_mech_info(
+            address="0xb", metadata_str="bbb", relevant_tools=set()
+        )
+
+        captured_specs = []
+
+        def _fake_fetch(specs, timeout, poll_interval=0.1):
+            captured_specs.extend(specs)
+            yield
+            return [MagicMock(), MagicMock()]
+
+        behaviour._fetch_http_parallel = _fake_fetch
+
+        _drive(behaviour.populate_tools([mech_a, mech_b]))
+
+        # Each spec must carry its own mech's CID, not the last-mutated URL.
+        assert CID_PREFIX + "aaa" in captured_specs[0]["url"]
+        assert CID_PREFIX + "bbb" in captured_specs[1]["url"]

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -980,3 +980,71 @@ class TestPopulateToolsParallelSemantics:
         # Each spec must carry its own mech's CID, not the last-mutated URL.
         assert CID_PREFIX + "aaa" in captured_specs[0]["url"]
         assert CID_PREFIX + "bbb" in captured_specs[1]["url"]
+
+    def test_primitive_wall_time_scales_with_max_not_sum_of_latencies(self) -> None:
+        """_fetch_http_parallel elapsed time tracks max(latencies), not sum.
+
+        Drives the real primitive with a simulated clock and callback
+        dispatcher: 5 requests with staggered arrival latencies
+        (50, 100, 150, 200, 500 ms). A sequential implementation would need
+        sum = 1000 ms of simulated time to complete; the parallel primitive
+        completes at max = 500 ms plus at most one poll_interval of slop.
+
+        The `elapsed < sum` assertion is the falsifiability point — it fails
+        for any serialized implementation.
+        """
+        # Reuse the TestFetchHttpParallel class's build helper by hand.
+        behaviour = _make_mech_info_behaviour()
+        behaviour._context.outbox = MagicMock()
+        behaviour._context.requests = MagicMock()
+        registry: dict = {}
+        behaviour._context.requests.request_id_to_callback = registry
+
+        nonces = [f"n{i}" for i in range(5)]
+        build_calls: list = []
+
+        def build(**kwargs):
+            idx = len(build_calls)
+            build_calls.append(kwargs)
+            msg = MagicMock(name=f"msg-{idx}")
+            dlg = MagicMock(name=f"dlg-{idx}")
+            dlg._parallel_nonce = nonces[idx]
+            return msg, dlg
+
+        behaviour._build_http_request_message = build
+        behaviour._get_request_nonce_from_dialogue = lambda d: d._parallel_nonce
+
+        latencies_ms = [50, 100, 150, 200, 500]
+        scheduled = {nonces[i]: latencies_ms[i] / 1000.0 for i in range(5)}
+        poll_interval = 0.1
+
+        current_time = [0.0]
+        behaviour._clock = lambda: current_time[0]
+
+        def fake_sleep(seconds):
+            current_time[0] += seconds
+            # Fire callbacks whose scheduled arrival has been reached.
+            for nonce in list(scheduled):
+                if scheduled[nonce] <= current_time[0] and nonce in registry:
+                    registry[nonce](MagicMock(name=nonce), behaviour)
+                    del scheduled[nonce]
+            yield
+
+        behaviour.sleep = fake_sleep
+
+        gen = behaviour._fetch_http_parallel(
+            [{"url": f"u{i}"} for i in range(5)],
+            timeout=10.0,
+            poll_interval=poll_interval,
+        )
+        result = _drive(gen)
+
+        assert all(r is not None for r in result)
+
+        max_lat = max(latencies_ms) / 1000.0  # 0.5s
+        sum_lat = sum(latencies_ms) / 1000.0  # 1.0s
+
+        # Elapsed tracks max, bounded by max + one poll_interval of slop.
+        assert current_time[0] <= max_lat + poll_interval * 1.5
+        # Falsifiability: sequential code needs sum_lat; parallel needs max_lat.
+        assert current_time[0] < sum_lat

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -36,10 +36,33 @@ def _make_mech_info_behaviour(**overrides) -> MechInformationBehaviour:
     behaviour._context = mock_context
     behaviour._fetch_status = FetchStatus.NONE
     behaviour._failed_mechs = set()
+    # Deterministic clock for parallel-fetch tests; always returns 0 until
+    # tests override. Overflow-safe for any reasonable timeout budget.
+    behaviour._clock = lambda: 0.0
 
     for key, value in overrides.items():
         setattr(behaviour, key, value)
 
+    return behaviour
+
+
+def _wire_parallel_fetch(
+    behaviour: MechInformationBehaviour,
+    clock_values=None,
+    registry=None,
+):
+    """Install outbox + requests mocks and a deterministic clock.
+
+    :param clock_values: iterable of floats returned by successive _clock()
+        calls. Default: constant 0.0 so timeout never fires.
+    :param registry: pre-populated request_id_to_callback dict; default empty.
+    """
+    behaviour._context.outbox = MagicMock()
+    behaviour._context.requests = MagicMock()
+    behaviour._context.requests.request_id_to_callback = registry or {}
+    if clock_values is not None:
+        it = iter(clock_values)
+        behaviour._clock = lambda: next(it)
     return behaviour
 
 
@@ -697,3 +720,181 @@ class TestPermanentErrorClassification:
         # Pre-Fix-2 this would be 7 (1 good + 6 broken retries).
         assert http_call_count["n"] == 2
         mock_api.increment_retries.assert_not_called()
+
+
+def _drive(gen):
+    """Run a generator to StopIteration, returning its .value."""
+    try:
+        while True:
+            next(gen)
+    except StopIteration as e:
+        return e.value
+
+
+def _step(gen):
+    """Advance a generator one yield; return True if still running."""
+    try:
+        next(gen)
+        return True
+    except StopIteration:
+        return False
+
+
+class TestFetchHttpParallel:
+    """Unit tests for MechInformationBehaviour._fetch_http_parallel."""
+
+    def _install_build_helpers(self, behaviour, nonces):
+        """Wire _build_http_request_message + _get_request_nonce_from_dialogue.
+
+        Returns a list of the dialogues so tests can introspect.
+        """
+        dialogues = []
+        build_calls = []
+
+        def build(**kwargs):
+            idx = len(build_calls)
+            build_calls.append(kwargs)
+            msg = MagicMock(name=f"msg-{idx}")
+            dlg = MagicMock(name=f"dlg-{idx}")
+            dlg._parallel_nonce = nonces[idx]
+            dialogues.append(dlg)
+            return msg, dlg
+
+        behaviour._build_http_request_message = build
+        behaviour._get_request_nonce_from_dialogue = lambda d: d._parallel_nonce
+        behaviour._build_calls = build_calls
+        return dialogues
+
+    def _install_counting_sleep(self, behaviour):
+        """Replace self.sleep with a counting generator yielding once."""
+        sleep_calls = []
+
+        def sleep(seconds):
+            sleep_calls.append(seconds)
+            yield
+
+        behaviour.sleep = sleep
+        behaviour._sleep_calls = sleep_calls
+
+    def test_fan_out_sends_all_messages_before_any_sleep(self) -> None:
+        """A1: put_message is called N times before the first sleep fires."""
+        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
+        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
+        self._install_counting_sleep(behaviour)
+
+        gen = behaviour._fetch_http_parallel(
+            [{"method": "GET", "url": "u1"}, {"method": "GET", "url": "u2"}, {"method": "GET", "url": "u3"}],
+            timeout=10.0,
+        )
+        # Drive just to the first yield (first sleep call).
+        _step(gen)
+
+        assert behaviour._context.outbox.put_message.call_count == 3
+        assert len(behaviour._sleep_calls) == 1
+        # All three callbacks registered before the first sleep.
+        registry = behaviour._context.requests.request_id_to_callback
+        assert set(registry.keys()) == {"n1", "n2", "n3"}
+
+    def test_responses_returned_in_input_order(self) -> None:
+        """A2: output order matches input order, not arrival order."""
+        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
+        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
+        self._install_counting_sleep(behaviour)
+
+        registry = behaviour._context.requests.request_id_to_callback
+        gen = behaviour._fetch_http_parallel(
+            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=10.0
+        )
+        _step(gen)  # fan-out done; first sleep yielded
+
+        msg1, msg2, msg3 = MagicMock(name="m1"), MagicMock(name="m2"), MagicMock(name="m3")
+        # Fire in reverse arrival order.
+        registry["n2"](msg2, behaviour)
+        registry["n3"](msg3, behaviour)
+        registry["n1"](msg1, behaviour)
+
+        result = _drive(gen)
+        assert result == [msg1, msg2, msg3]
+
+    def test_timed_out_entries_are_none(self) -> None:
+        """A3: timeout yields None for unresponded requests."""
+        behaviour = _wire_parallel_fetch(
+            _make_mech_info_behaviour(),
+            # _clock() is called at deadline-setup then on each loop iteration.
+            clock_values=[0.0, 0.05, 100.0],
+        )
+        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
+        self._install_counting_sleep(behaviour)
+
+        registry = behaviour._context.requests.request_id_to_callback
+        gen = behaviour._fetch_http_parallel(
+            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=1.0
+        )
+        _step(gen)
+
+        msg2 = MagicMock(name="m2")
+        registry["n2"](msg2, behaviour)
+
+        result = _drive(gen)
+        assert result == [None, msg2, None]
+
+    def test_cleanup_pops_unresolved_nonces_from_registry(self) -> None:
+        """A4: on exit, registry is cleared of every nonce we registered."""
+        behaviour = _wire_parallel_fetch(
+            _make_mech_info_behaviour(), clock_values=[0.0, 0.05, 100.0]
+        )
+        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
+        self._install_counting_sleep(behaviour)
+
+        registry = behaviour._context.requests.request_id_to_callback
+        gen = behaviour._fetch_http_parallel(
+            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=1.0
+        )
+        _step(gen)
+        # No responses; timeout expires.
+        _drive(gen)
+
+        assert "n1" not in registry
+        assert "n2" not in registry
+        assert "n3" not in registry
+
+    def test_cleanup_runs_on_exception(self) -> None:
+        """A5: unresolved nonces popped even when sleep raises."""
+        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
+        self._install_build_helpers(behaviour, ["n1", "n2"])
+
+        def boom_sleep(seconds):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover - make it a generator function
+
+        behaviour.sleep = boom_sleep
+        registry = behaviour._context.requests.request_id_to_callback
+
+        gen = behaviour._fetch_http_parallel(
+            [{"url": "u1"}, {"url": "u2"}], timeout=10.0
+        )
+        try:
+            _drive(gen)
+        except RuntimeError:
+            pass
+
+        assert "n1" not in registry
+        assert "n2" not in registry
+
+    def test_custom_callback_writes_to_results_without_touching_behaviour(self) -> None:
+        """A6: _make_parallel_fetch_callback is behaviour-state-agnostic."""
+        from packages.valory.skills.mech_interact_abci.behaviours.mech_info import (
+            _make_parallel_fetch_callback,
+        )
+
+        results: dict = {}
+        cb = _make_parallel_fetch_callback(results, "nX")
+        mock_message = MagicMock()
+        mock_current_behaviour = MagicMock()
+
+        cb(mock_message, mock_current_behaviour)
+
+        assert results["nX"] is mock_message
+        # No calls of any kind on current_behaviour — not try_send, not state.
+        mock_current_behaviour.assert_not_called()
+        assert not mock_current_behaviour.method_calls


### PR DESCRIPTION
## Summary

Fix 4 from the follow-up plan on PR #66. Parallelizes the IPFS manifest fetches in `MechInformationBehaviour.populate_tools` so broken mechs don't serialise a fresh agent restart into a round timeout.

**Based on PR #68** (permanent-error classifier) — this PR targets that branch. After #68 merges, I'll rebase onto main.

Problem: PR #66 gave us per-mech quarantine; PR #68 collapsed permanent-error quarantine to 1 attempt. Both still run sequentially — N broken mechs take N × RTT wall-clock. Observed 2.1s for the reported `0x33ca1e11…` case; ceiling at 30s round timeout is ~85 permanently-broken mechs with PR #68 alone. After this PR: effectively unbounded (wall time = `max(per-mech RTT)`).

## Approach

`BaseBehaviour.get_http_response` is sequential by design — `wait_for_message` explicitly forbids concurrent requests. But the underlying infrastructure is concurrency-friendly: `Requests.request_id_to_callback` is nonce-keyed (`secrets.token_hex(32)` — never collides), `AbstractResponseHandler` dispatches by nonce, `put_message` is non-blocking.

Added a local helper `_fetch_http_parallel` on `MechInformationBehaviour` that:

1. Calls `_build_http_request_message` N times (unique nonce per dialogue).
2. Registers **custom** nonce-scoped callbacks (not `get_callback_request` — that routes through `try_send` which is serial and state-dependent).
3. Puts all N messages to outbox up front.
4. Polls via `self.sleep` until every callback has fired or a timeout budget expires.
5. Cleans up unresolved nonces from the registry in `finally` so late responses don't keep closures alive across rounds.

The custom callback is dead-simple and behaviour-state-agnostic:

```python
def _make_parallel_fetch_callback(results, nonce):
    def _callback(message, current_behaviour):
        results[nonce] = message
    return _callback
```

## Semantics changes worth highlighting

- **Shared retry counter advances once per batch pass**, not per-mech. On exhaustion, all still-unpopulated mechs are quarantined together.
- **Timed-out fetches** (None response) are treated as transient; increment the shared counter, quarantine only on retry exhaustion.
- **Specs are snapshotted per mech** before the shared URL is mutated for the next mech.

Full design/rationale: `/home/lockhart/.claude/plans/mech-info-parallel-fetch.md` (local). Issue #67 has a thinner earlier draft (now obsolete — see this PR).

## New skill param

`mech_tools_parallel_timeout: 20.0` (seconds) — leaves 10s of the 30s round budget for subgraph fetch + consensus payload. **Optional with a 20.0s default** (`kwargs.get`, not `_ensure`), so downstream skills inheriting `MechParams` (trader_abci, market_manager_abci, etc.) don't need to touch their `skill.yaml` to pick up this fix.

## Commits

- `e194766` — `_fetch_http_parallel` primitive + 6 isolation tests.
- `60c51ae` — `populate_tools` rewrite + 6 parallel-semantics tests + adapted existing tests.
- `060fc1b` — fix: make `mech_tools_parallel_timeout` optional so downstream skills load without config changes.

## Test plan

- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py::TestFetchHttpParallel -rfE` — 6 tests: fan-out, input-order return, timeout-returns-None, registry cleanup on timeout, registry cleanup on exception, custom callback isolation.
- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py::TestPopulateToolsParallelSemantics -rfE` — 6 tests: mixed-outcome batch, single-counter-advance per pass, batch-quarantine on exhaustion, timeout-as-transient, zero-pending early return, per-mech spec snapshot.
- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests -rfE` — 364 passed.
- [x] `uv run tomte check-code` — all 6 linters green.
- [x] `make generators` — skill hash updated.
- [x] **Real trader2 smoke test against `0x33ca1e11…`** (log `2026-04-14 00:58:38→00:58:42`):
  - `mech_information_round` → `Event.DONE` in ~4s (dominated by subgraph fetch upstream).
  - Single `Could not get` warning, single `Quarantining mech 0x33ca1e11…: permanent content error … retries skipped.` No retries.
  - FSM advances normally past `mech_information_round` → `fetch_markets_router_round` → `update_bets_round` → etc.
- [x] **Downstream skill load** — trader_abci loads without needing `mech_tools_parallel_timeout` in its `skill.yaml` (verified after `060fc1b`).
- [ ] Synthetic N-broken-mech run — not executed (the `0x33ca1e11…` case is the only permanently-broken mech observed; we'd need to stand up bogus CIDs to stress it).

## References

- Infrastructure trace: `abstract_round_abci/behaviour_utils.py:1259-1398`, `handlers.py:354-489`, `dialogues.py:99-125`, `models.py:547-556`.
- PR #66 (per-mech quarantine) — merged.
- PR #68 (permanent-error classifier) — this PR's base.
- Issue #67 — tracking issue; spec now obsolete (replaced by the design above and the local plan file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)