### PR TITLE
docs: migrate setup instructions from pipenv to uv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,12 @@ Mech-interact is an Open Autonomy skill implementing interactions with AI mechs 
 ## Development Setup
 
 ```bash
-make new_env && pipenv shell
-autonomy init --reset --author valory --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
-autonomy packages sync --update-packages
+uv sync
+uv run autonomy init --reset --author valory --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
+uv run autonomy packages sync --update-packages
 ```
+
+Prefix commands with `uv run` (e.g. `uv run pytest ...`, `uv run make test`).
 
 ## Common Commands
 
@@ -86,7 +88,7 @@ Each contract package contains:
 
 ### Key Conventions
 
-- Dependencies are managed via `Pipfile` (dev) and `tox.ini` (CI). No pyproject.toml or requirements.txt.
+- Dependencies are managed via `pyproject.toml` + `uv.lock` (via `uv`) and `tox.ini` (CI).
 - Package hashes in `packages/packages.json` must stay in sync — run `autonomy packages lock` after modifying packages.
 - Code style: black (line length 88), isort, flake8, mypy with `--disallow-untyped-defs`, darglint (sphinx-style docstrings).
 - Third-party AEA packages are synced from IPFS, not vendored. Only `packages/valory/` contains project-owned code.

--- a/Makefile
+++ b/Makefile
@@ -86,27 +86,6 @@ test:
 	--cov-report=xml --cov-report=term --cov-report=term-missing --cov-config=.coveragerc
 	find . -name ".coverage*" -not -name ".coveragerc" -exec rm -fr "{}" \;
 
-v := $(shell pip -V | grep virtualenvs)
-
-.PHONY: new_env
-new_env: clean
-	if [ ! -z "$(which svn)" ];\
-	then\
-		echo "The development setup requires SVN, exit";\
-		exit 1;\
-	fi;\
-
-	if [ -z "$v" ];\
-	then\
-		pipenv --rm;\
-		pipenv --clear;\
-		pipenv --python 3.10;\
-		pipenv install --dev --skip-lock;\
-		echo "Enter virtual environment with all development dependencies now: 'pipenv shell'.";\
-	else\
-		echo "In a virtual environment! Exit first: 'exit'.";\
-	fi
-
 .PHONY: fix-abci-app-specs
 fix-abci-app-specs:
 	export PYTHONPATH=${PYTHONPATH}:${PWD}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An Open Autonomy skill that implements interactions with mechs.
     - Python `>=3.8`
     - [Tendermint](https://docs.tendermint.com/v0.34/introduction/install.html) `==0.34.19`
     - [IPFS node](https://docs.ipfs.io/install/command-line/#official-distributions) `==0.6.0`
-    - [Pipenv](https://pipenv.pypa.io/en/latest/installation.html) `>=2021.x.xx`
+    - [uv](https://docs.astral.sh/uv/getting-started/installation/)
     - [Docker Engine](https://docs.docker.com/engine/install/) `<25.0`
     - [Docker Compose](https://docs.docker.com/compose/install/)
 
@@ -24,12 +24,12 @@ An Open Autonomy skill that implements interactions with mechs.
 
 - Create development environment:
 
-      make new_env && pipenv shell
+      uv sync
 
 - Configure command line:
 
-      autonomy init --reset --author valory --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
+      uv run autonomy init --reset --author valory --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
 
 - Pull packages:
 
-      autonomy packages sync --update-packages
+      uv run autonomy packages sync --update-packages


### PR DESCRIPTION
## Summary
- Update CLAUDE.md and README.md dev-setup commands to use `uv sync` / `uv run` instead of `pipenv`.
- Drop the now-unused `new_env` target from the Makefile.

## Test plan
- [ ] `uv sync` works from a clean clone
- [ ] `uv run autonomy init ...` and `uv run autonomy packages sync --update-packages` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)