### PR TITLE
ci: add aggregate All-checks-passed gate and make tests blocking

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -127,7 +127,7 @@ jobs:
           gitleaks detect --report-format json --report-path leak_report -v
 
   test:
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - lock_check
       - copyright_and_doc_check
@@ -305,3 +305,22 @@ jobs:
       - name: e2e tests
         run: |
           tox -e e2e-py${{ matrix.python-version }}-linux
+
+  all-checks-passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_doc_check
+      - linter_checks
+      - scan
+      - test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify no failures or cancellations
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed."


### PR DESCRIPTION
## Summary
- Add an `all-checks-passed` aggregate meta job that fans in from all mandatory CI jobs (`lock_check`, `copyright_and_doc_check`, `linter_checks`, `scan`, `test`). It runs with `if: always()` and fails if any dependency failed or was cancelled.
- Flip `continue-on-error` on the `test` matrix from `True` to `False` so unit-test failures actually block merges.
- Enables branch protection on `main` to require a single `All checks passed` context; future additions/removals of mandatory checks are managed by editing the job's `needs:` list rather than by editing branch protection.

## Test plan
- [ ] Confirm the new `all-checks-passed` job appears in this PR's checks and turns green once its dependencies succeed.
- [ ] Confirm the `test` matrix still completes on all three OSes and five Python versions with `continue-on-error: False` (no hidden flakes surface).
- [ ] After merge, apply branch protection requiring `All checks passed` and verify a follow-up PR is blocked until the aggregate job reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
