### PR TITLE
revert(mech_info): drop parallel fetch, coalesce by CID instead

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeifip7e6al6nwtwbyqol4xm2iqnuycrdefdie7vyxlxeh33ubqeooa",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeie267gridf6z2yxk7cvt5fdy66cocyg5dn3rj7zvnvl3otnk6iw34",
         "contract/valory/subscription_provider/0.1.0": "bafybeibulnegkf7jsz4lrhvsvai65wytjspl6itkhb6dhbl3fwsbpbyh6u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeidq4vfhz5hvixmzor4epnnh2xzhhzedcxhxfoa6nqgqjp3yqhktdu"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihazofcrox6qvvxojxm4t7ezic4llxwvleoalfk67vqdevukwy3zi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -21,12 +21,8 @@
 """This module contains the behaviour responsible for gathering information about the mech marketplace."""
 
 import json
-import time
-from typing import Any, Callable, Dict, Generator, List, Optional, Set
+from typing import Any, Dict, Generator, List, Optional, Set
 
-from aea.protocols.base import Message
-
-from packages.valory.protocols.http import HttpMessage
 from packages.valory.skills.mech_interact_abci.behaviours.base import (
     MechInteractBaseBehaviour,
     WaitableConditionType,
@@ -47,25 +43,6 @@ from packages.valory.skills.mech_interact_abci.states.mech_info import (
 )
 
 CID_PREFIX = "f01701220"
-PARALLEL_FETCH_POLL_INTERVAL = 0.1
-
-
-def _make_parallel_fetch_callback(
-    results: Dict[str, Optional[HttpMessage]], nonce: str
-) -> Callable[[Message, Any], None]:
-    """Build a nonce-scoped callback that stores the response in results.
-
-    Stays behaviour-state-agnostic so it dispatches regardless of whether the
-    owning behaviour is in WAITING_MESSAGE state (we aren't — we poll via
-    self.sleep while the fetch is in flight).
-    """
-
-    def _callback(message: Message, current_behaviour: Any) -> None:
-        # The mech_interact parallel fetcher only ever receives HttpMessage
-        # responses for these nonces; the cast is safe by construction.
-        results[nonce] = message  # type: ignore[assignment]
-
-    return _callback
 
 
 class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
@@ -78,8 +55,6 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         super().__init__(**kwargs)
         self._fetch_status: FetchStatus = FetchStatus.NONE
         self._failed_mechs: Set[str] = set()
-        # Injectable clock for deterministic parallel-fetch timeout tests.
-        self._clock: Callable[[], float] = time.monotonic
 
     @property
     def mech_tools_api(self) -> MechToolsSpecs:  # pragma: no cover
@@ -95,166 +70,74 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
         self.mech_tools_api.__dict__["_frozen"] = True
 
     def _quarantine_mech(self, mech_address: str, reason: str) -> None:
-        """Log the quarantine and mark the mech failed for this round.
-
-        Retry-counter resets are owned by populate_tools' end-of-pass logic
-        in the parallel design, not by this helper — calling reset_retries
-        here would clobber any in-flight transient counter for the rest of
-        the batch.
-        """
+        """Log the quarantine and mark the mech failed for this round."""
         self.context.logger.error(f"Quarantining mech {mech_address}: {reason}")
         self._failed_mechs.add(mech_address)
-
-    def _fetch_http_parallel(
-        self,
-        specs: List[Dict[str, Any]],
-        timeout: float,
-        poll_interval: float = PARALLEL_FETCH_POLL_INTERVAL,
-    ) -> Generator[None, None, List[Optional[HttpMessage]]]:
-        """Fire N HTTP requests concurrently; return responses in input order.
-
-        :param specs: list of kwargs dicts for _build_http_request_message.
-        :param timeout: wall-clock budget (via self._clock) for the whole batch.
-        :param poll_interval: sleep between readiness checks.
-        :return: list with one entry per input spec; None for timed-out
-            requests. Unresolved callbacks are popped from the request
-            registry on exit.
-        :yield: None while awaiting responses.
-        """
-        results: Dict[str, Optional[HttpMessage]] = {}
-        nonces: List[str] = []
-        registry = self.context.requests.request_id_to_callback
-
-        # This primitive relies on three BaseBehaviour / skill-context
-        # invariants. If any of them changes, the parallel path breaks
-        # silently and should be reworked rather than patched:
-        #   1. context.requests.request_id_to_callback is a nonce-keyed dict
-        #      the HTTP response handler consults to dispatch incoming
-        #      messages — we register callbacks directly against it.
-        #   2. context.outbox.put_message is non-blocking (the multiplexer
-        #      schedules the envelope asynchronously), so the fan-out loop
-        #      can send N messages before yielding even once.
-        #   3. The response handler dispatches by dialogue nonce, not by
-        #      behaviour state — this behaviour stays in RUNNING and polls
-        #      via self.sleep, and still receives responses via the
-        #      registered callbacks.
-        try:
-            # Registration is inside the try so any framework-method raise
-            # mid-fan-out still triggers the finally-block cleanup of the
-            # nonces already inserted (otherwise their closures would leak
-            # across rounds and capture stale `results` dicts).
-            for spec in specs:
-                message, dialogue = self._build_http_request_message(**spec)
-                nonce = self._get_request_nonce_from_dialogue(dialogue)
-                nonces.append(nonce)
-                registry[nonce] = _make_parallel_fetch_callback(results, nonce)
-                self.context.outbox.put_message(message=message)
-
-            deadline = self._clock() + timeout
-            while len(results) < len(nonces):
-                if self._clock() >= deadline:
-                    break
-                yield from self.sleep(poll_interval)
-        finally:
-            for nonce in nonces:
-                registry.pop(nonce, None)
-
-        return [results.get(n) for n in nonces]
 
     def populate_tools(
         self, mech_info: MechsSubgraphResponseType
     ) -> WaitableConditionType:
-        """Populate the tools of the mech info, using the metadata, in parallel."""
-        pending = [
-            mech
-            for mech in mech_info
-            if not mech.relevant_tools and mech.address not in self._failed_mechs
-        ]
-        if not pending:
-            # Symmetric with the end-of-pass reset below: every exit path
-            # from populate_tools leaves the shared retry counter at zero,
-            # so future refactors can rely on that invariant.
-            self.mech_tools_api.reset_retries()
-            return True
+        """Populate the tools of the mech info, fetching once per distinct CID.
 
-        specs_per_mech: List[Dict[str, Any]] = []
-        for mech in pending:
-            # set_mech_agent_specs mutates mech_tools_api.url. Snapshot
-            # get_spec() BEFORE advancing to the next mech so each sent
-            # request carries its own mech's CID.
-            self.set_mech_agent_specs(mech.service.metadata_str)
-            specs_per_mech.append(dict(self.mech_tools_api.get_spec()))
-
-        responses = yield from self._fetch_http_parallel(
-            specs_per_mech,
-            timeout=self.params.mech_tools_parallel_timeout,
-        )
-
-        any_transient = False
-        # Zip in specs_per_mech so URL logging uses the per-mech snapshot
-        # rather than self.mech_tools_api.url, which has been mutated to the
-        # last mech's CID by the snapshot loop above.
-        for mech, spec, res_raw in zip(pending, specs_per_mech, responses):
-            mech_url = spec.get("url", "<unknown>")
-            if res_raw is None:
-                self.context.logger.warning(
-                    f"Timed out fetching {mech.address} mech agent's tools "
-                    f"from {mech_url}."
-                )
-                any_transient = True
+        Mechs that share the same metadata CID resolve to the same IPFS
+        manifest, so they are grouped and fetched once per CID. The resulting
+        tool set is applied to every mech in the group.
+        """
+        pending_by_cid: Dict[str, List[Any]] = {}
+        for mech in mech_info:
+            if mech.relevant_tools or mech.address in self._failed_mechs:
                 continue
+            pending_by_cid.setdefault(mech.service.metadata_str, []).append(mech)
 
+        for metadata_str, mechs in pending_by_cid.items():
+            self.set_mech_agent_specs(metadata_str)
+            specs = self.mech_tools_api.get_spec()
+            res_raw = yield from self.get_http_response(**specs)
             res = self.mech_tools_api.process_response(res_raw)
 
             if res is None:
                 self.context.logger.warning(
-                    f"Could not get the {mech.address} mech agent's tools "
-                    f"from {mech_url}."
+                    f"Could not get tools manifest at {self.mech_tools_api.url} "
+                    f"(shared by {len(mechs)} mech(s))."
                 )
                 if self.mech_tools_api.is_permanent_error(res_raw):
-                    self._quarantine_mech(
-                        mech.address,
-                        f"permanent content error at {mech_url} "
-                        f"(status={res_raw.status_code}); retries skipped.",
+                    reason = (
+                        f"permanent content error at {self.mech_tools_api.url} "
+                        f"(status={res_raw.status_code}); retries skipped."
                     )
-                else:
-                    any_transient = True
-                continue
+                    for mech in mechs:
+                        self._quarantine_mech(mech.address, reason)
+                    self.mech_tools_api.reset_retries()
+                    return False
+
+                self.mech_tools_api.increment_retries()
+                if self.mech_tools_api.is_retries_exceeded():
+                    reason = (
+                        f"could not fetch tools manifest at "
+                        f"{self.mech_tools_api.url} after retries exhausted."
+                    )
+                    for mech in mechs:
+                        self._quarantine_mech(mech.address, reason)
+                    self.mech_tools_api.reset_retries()
+                return False
 
             if len(res) == 0:
                 self.context.logger.warning(
-                    f"Quarantining mech {mech.address}: tools manifest at "
-                    f"{mech_url} is empty. Empty lists are "
+                    f"Tools manifest at {self.mech_tools_api.url} is empty "
+                    f"(shared by {len(mechs)} mech(s)). Empty lists are "
                     f"deterministic per-CID; will retry on next round entry."
                 )
-                self._failed_mechs.add(mech.address)
+                for mech in mechs:
+                    self._failed_mechs.add(mech.address)
+                self.mech_tools_api.reset_retries()
                 continue
 
             relevant_tools = set(res) - self.params.irrelevant_tools
-            mech.relevant_tools |= relevant_tools
-
-        # Advance the shared retry counter once per pass that had transient
-        # failures. On exhaustion, quarantine every still-unpopulated mech.
-        if any_transient:
-            self.mech_tools_api.increment_retries()
-            if self.mech_tools_api.is_retries_exceeded():
-                for mech in pending:
-                    if (
-                        not mech.relevant_tools
-                        and mech.address not in self._failed_mechs
-                    ):
-                        self._quarantine_mech(
-                            mech.address,
-                            "retries exhausted after transient failures.",
-                        )
-                self.mech_tools_api.reset_retries()
-        else:
+            for mech in mechs:
+                mech.relevant_tools |= relevant_tools
             self.mech_tools_api.reset_retries()
 
-        return all(
-            mech.relevant_tools or mech.address in self._failed_mechs
-            for mech in pending
-        )
+        return True
 
     def get_mechs_info(
         self,

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -293,11 +293,6 @@ class MechParams(BaseParams):
             "use_acn_for_delivers", kwargs, bool
         )
         self.irrelevant_tools: set = set(self._ensure("irrelevant_tools", kwargs, list))
-        # Optional with a safe default: downstream skills inheriting MechParams
-        # don't need to touch their skill.yaml to pick up this fix.
-        self.mech_tools_parallel_timeout: float = float(
-            kwargs.get("mech_tools_parallel_timeout", 20.0)
-        )
         self.ignored_mechs: FrozenSet[str] = frozenset(
             self._ensure("ignored_mechs", kwargs, List[str])
         )

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
-  behaviours/mech_info.py: bafybeiexut5veu2s2qr6mvlauijwkfcskzvdekjltwkbdl7ixkuf5m657y
+  behaviours/mech_info.py: bafybeidleagib3fzbtehwotw54isgtc3kdwuvhxq3e3icccvky7cixzywy
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeigbd652kkbd4q42za3mn26ixnb5te6yu3ms5dr54w5h4oqov4pxya
   behaviours/request.py: bafybeia2c4ms6vya5kqae4qxi3tc3pe4dw2pmo5mxvu4ewrtz7av5e7gwy
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeigmk3y3uwlsmzommqwimirko6vph3j6mmymxbncshjdzebne4nija
   graph_tooling/requests.py: bafybeieebeky62sm2fzqy5egbg4fk5cbi2loywgl6x5dbfraatygmlqe4m
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeihehkn644fxs5wfrqi7fjuzthncealwjgixjkevit7o3q5vxixn2u
+  models.py: bafybeicwbvexmcgpj3qpvntawvlm62ljgwmdqnh4u5tekatqwjs3uz4gye
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeiewhynivpu72vzstzppmqedoytidmfgjszf7mb22ml7lhi5ep6eyy
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeic7jsbsnvmw7byuktnlhtkd7pav7xtl5nyxg266dwtzlbq75zayze
-  tests/test_mech_info_behaviour.py: bafybeificwrmpvyrakbnhuwzlecaml3i4xqoeehhnls6hm7cchh5hlwsaa
+  tests/test_mech_info_behaviour.py: bafybeibtdp6pcryedixwplb3kdy7ej236dakbuhdoirnf3dnbhnyhxxzvu
   tests/test_models.py: bafybeicoqkpqrcqkewxy2ipuw6cfzqxjoljew36vjbc3hwsfcyvkjewame
   tests/test_payloads.py: bafybeihcllq2rgswue4w353e24ec42v62fkdm6l7ek3uzcxsmqk76skwba
   tests/test_request_behaviour.py: bafybeiheu4ohjxtibmk6qyju23nvbwie5iwrcjyjntumde7theocwxba7e
@@ -224,7 +224,6 @@ models:
       - stabilityai-stable-diffusion-768-v2-1
       deliveries_lookback_days: 30
       ignored_mechs: []
-      mech_tools_parallel_timeout: 20.0
       penalize_mech_time_window: 1800
     class_name: Params
   mech_tools:

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -36,48 +36,10 @@ def _make_mech_info_behaviour(**overrides) -> MechInformationBehaviour:
     behaviour._context = mock_context
     behaviour._fetch_status = FetchStatus.NONE
     behaviour._failed_mechs = set()
-    # Deterministic clock for parallel-fetch tests; always returns 0 until
-    # tests override. Overflow-safe for any reasonable timeout budget.
-    behaviour._clock = lambda: 0.0
 
     for key, value in overrides.items():
         setattr(behaviour, key, value)
 
-    return behaviour
-
-
-def _wire_parallel_fetch(
-    behaviour: MechInformationBehaviour,
-    clock_values=None,
-    registry=None,
-):
-    """Install outbox + requests mocks and a deterministic clock.
-
-    :param clock_values: iterable of floats returned by successive _clock()
-        calls. Default: constant 0.0 so timeout never fires.
-    :param registry: pre-populated request_id_to_callback dict; default empty.
-    """
-    behaviour._context.outbox = MagicMock()
-    behaviour._context.requests = MagicMock()
-    behaviour._context.requests.request_id_to_callback = registry or {}
-    if clock_values is not None:
-        it = iter(clock_values)
-        behaviour._clock = lambda: next(it)
-    return behaviour
-
-
-def _install_fake_parallel_fetch(behaviour, responses):
-    """Replace behaviour._fetch_http_parallel with a generator returning responses.
-
-    Each element of `responses` maps 1:1 to a pending mech in populate_tools.
-    A value of None represents a timed-out request.
-    """
-
-    def _fake_fetch(specs, timeout, poll_interval=0.1):
-        yield
-        return list(responses)
-
-    behaviour._fetch_http_parallel = _fake_fetch
     return behaviour
 
 
@@ -103,6 +65,44 @@ def _make_mech_info(
     )
 
 
+def _drive(gen):
+    """Run a generator to StopIteration, returning its .value."""
+    try:
+        while True:
+            next(gen)
+    except StopIteration as e:
+        return e.value
+
+
+def _wire_get_http_response(behaviour, responses):
+    """Wire behaviour.get_http_response to return values in order."""
+    iter_vals = iter(responses)
+
+    def mock_get_http_response(**kwargs):
+        yield
+        return next(iter_vals)
+
+    behaviour.get_http_response = mock_get_http_response
+
+
+def _setup_api(behaviour, **overrides):
+    """Set up a behaviour with mocked context.params and mech_tools_api."""
+    behaviour._context.params = MagicMock()
+    behaviour._context.params.ipfs_address = "https://ipfs.io/"
+    behaviour._context.params.irrelevant_tools = set()
+
+    api = MagicMock()
+    api.__dict__["_frozen"] = True
+    api.url = "http://test/hash"
+    api.get_spec = lambda: {"url": api.url, "method": "GET"}
+
+    for key, value in overrides.items():
+        setattr(api, key, value)
+
+    behaviour._context.mech_tools = api
+    return api
+
+
 class TestSetMechAgentSpecs:
     """Tests for set_mech_agent_specs."""
 
@@ -126,272 +126,19 @@ class TestPopulateTools:
     """Tests for the populate_tools generator method."""
 
     def test_skips_mechs_with_existing_tools(self) -> None:
-        """Test that mechs with already-populated tools are skipped."""
+        """Mechs whose relevant_tools is already populated are not refetched."""
         behaviour = _make_mech_info_behaviour()
         mech = _make_mech_info(relevant_tools={"tool1", "tool2"})
 
-        gen = behaviour.populate_tools([mech])
-        try:
-            gen.send(None)  # start generator
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is True
         assert mech.relevant_tools == {"tool1", "tool2"}
 
-    def test_populates_tools_from_http_response(self) -> None:
-        """Test that tools are fetched via HTTP and populated on mech info."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = {"irrelevant_tool"}
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = ["tool_a", "tool_b", "irrelevant_tool"]
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is True
-        assert mech.relevant_tools == {"tool_a", "tool_b"}
-        mock_api.reset_retries.assert_called_once()
-
-    def test_returns_false_on_failed_http(self) -> None:
-        """Test that failed HTTP response returns False and increments retries."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None  # failed
-        mock_api.is_retries_exceeded.return_value = False
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/hash"
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is False
-        mock_api.increment_retries.assert_called_once()
-        behaviour.context.logger.warning.assert_called()
-
-    def test_quarantines_on_empty_tools(self) -> None:
-        """Empty tools list is deterministic per-CID; mech is quarantined."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = []  # empty
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(address="0xempty", relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is True
-        assert "0xempty" in behaviour._failed_mechs
-        assert mech.relevant_tools == set()
-        warning_calls = behaviour.context.logger.warning.call_args_list
-        assert any("empty" in str(call) for call in warning_calls)
-        mock_api.reset_retries.assert_called_once()
-
-    def test_multiple_mechs_processes_all(self) -> None:
-        """Test that populate_tools processes all mechs in parallel in one pass."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.side_effect = [["tool_1"], ["tool_2"]]
-        behaviour._context.mech_tools = mock_api
-
-        mech1 = _make_mech_info(address="0xmech1", relevant_tools=set())
-        mech2 = _make_mech_info(address="0xmech2", relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock(), MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech1, mech2]))
-
-        assert result is True
-        assert mech1.relevant_tools == {"tool_1"}
-        assert mech2.relevant_tools == {"tool_2"}
-
-
-class TestGetMechsInfo:
-    """Tests for the get_mechs_info generator method."""
-
-    def test_returns_none_on_fetch_failure(self) -> None:
-        """Test get_mechs_info returns None when fetch_mechs_info fails."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._fetch_status = FetchStatus.IN_PROGRESS  # not SUCCESS
-
-        def mock_fetch_mechs_info():
-            yield
-            return []
-
-        behaviour.fetch_mechs_info = mock_fetch_mechs_info
-
-        gen = behaviour.get_mechs_info()
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
-
-        assert result is None
-
-    def test_returns_none_on_empty_info(self) -> None:
-        """Test get_mechs_info returns None when mech info is empty."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._fetch_status = FetchStatus.SUCCESS
-
-        def mock_fetch_mechs_info():
-            behaviour._fetch_status = FetchStatus.SUCCESS
-            yield
-            return []
-
-        behaviour.fetch_mechs_info = mock_fetch_mechs_info
-
-        gen = behaviour.get_mechs_info()
-        try:
-            next(gen)
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
-
-        assert result is None
-
-
-class TestQuarantine:
-    """Tests for per-mech quarantine on IPFS fetch failure."""
-
-    def test_populate_tools_quarantines_mech_after_retries_exhausted(self) -> None:
-        """A transient mech whose retries are exhausted is added to _failed_mechs."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_retries_exceeded.return_value = True
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/broken-cid"
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(address="0xbroken", relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is True  # mech now quarantined, no more work
-        assert "0xbroken" in behaviour._failed_mechs
-        mock_api.reset_retries.assert_called_once()
-        behaviour.context.logger.error.assert_called()
-
-    def test_populate_tools_does_not_quarantine_before_retries_exceeded(self) -> None:
-        """Transient failure with retries remaining leaves _failed_mechs empty."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_retries_exceeded.return_value = False
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/broken-cid"
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(address="0xtransient", relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is False
-        assert behaviour._failed_mechs == set()
-        mock_api.increment_retries.assert_called_once()
-        mock_api.reset_retries.assert_not_called()
-
-    def test_quarantine_only_fires_on_final_retry(self) -> None:
-        """Across N passes, retry counter advances once per pass; quarantine only on exhaustion."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        retries_limit = 3
-        call_count = {"n": 0}
-
-        def is_retries_exceeded_side_effect():
-            return call_count["n"] >= retries_limit
-
-        def increment_retries_side_effect():
-            call_count["n"] += 1
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_retries_exceeded.side_effect = is_retries_exceeded_side_effect
-        mock_api.increment_retries.side_effect = increment_retries_side_effect
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/broken-cid"
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(address="0xflaky", relevant_tools=set())
-
-        # Each populate_tools pass sees one transient failure.
-        # The fake is re-used across passes.
-        iterations = 0
-        while True:
-            iterations += 1
-            _install_fake_parallel_fetch(behaviour, [MagicMock()])
-            outcome = _drive(behaviour.populate_tools([mech]))
-            if outcome:
-                break
-            if iterations < retries_limit:
-                assert behaviour._failed_mechs == set()
-
-        # Quarantine fires on the pass that exhausts retries (same iteration
-        # as the Nth increment), so we expect exactly retries_limit passes.
-        assert iterations == retries_limit
-        assert "0xflaky" in behaviour._failed_mechs
-        assert mock_api.increment_retries.call_count == retries_limit
-
-    def test_populate_tools_skips_quarantined_mechs(self) -> None:
-        """A mech already in _failed_mechs is not fetched again."""
+    def test_skips_quarantined_mechs(self) -> None:
+        """Mechs in _failed_mechs are not fetched."""
         behaviour = _make_mech_info_behaviour()
         behaviour._failed_mechs = {"0xbroken"}
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        behaviour._context.mech_tools = mock_api
 
         called = {"count": 0}
 
@@ -404,96 +151,81 @@ class TestQuarantine:
 
         mech = _make_mech_info(address="0xbroken", relevant_tools=set())
 
-        gen = behaviour.populate_tools([mech])
-        try:
-            gen.send(None)
-        except StopIteration as e:
-            result = e.value
+        result = _drive(behaviour.populate_tools([mech]))
 
         assert result is True
         assert called["count"] == 0
 
-    def test_get_mechs_info_partial_success_returns_serialized_json(self) -> None:
-        """One good mech + one broken mech returns JSON with both; broken has empty tools."""
+    def test_populates_tools_from_http_response(self) -> None:
+        """Tools fetched via HTTP and populated on the mech."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._fetch_status = FetchStatus.SUCCESS
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
+        api = _setup_api(behaviour)
+        api.process_response.return_value = ["tool_a", "tool_b", "irrelevant_tool"]
+        behaviour._context.params.irrelevant_tools = {"irrelevant_tool"}
 
-        good = _make_mech_info(address="0xgood", relevant_tools=set())
-        broken = _make_mech_info(address="0xbroken", relevant_tools=set())
+        mech = _make_mech_info(relevant_tools=set())
+        _wire_get_http_response(behaviour, [MagicMock()])
 
-        def mock_fetch_mechs_info():
-            behaviour._fetch_status = FetchStatus.SUCCESS
-            yield
-            return [good, broken]
+        result = _drive(behaviour.populate_tools([mech]))
 
-        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+        assert result is True
+        assert mech.relevant_tools == {"tool_a", "tool_b"}
+        api.reset_retries.assert_called_once()
 
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.side_effect = [["tool_good"], None]
-        mock_api.is_retries_exceeded.return_value = True
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/broken"
-        behaviour._context.mech_tools = mock_api
-        _install_fake_parallel_fetch(behaviour, [MagicMock(), MagicMock()])
-
-        result = _drive(behaviour.get_mechs_info())
-
-        assert result is not None
-        assert "0xgood" in result
-        assert "0xbroken" in result
-        assert good.relevant_tools == {"tool_good"}
-        assert broken.relevant_tools == set()
-        assert "0xbroken" in behaviour._failed_mechs
-
-    def test_get_mechs_info_all_failed_returns_none(self) -> None:
-        """If every mech fails, result is None so the round can retry."""
+    def test_returns_false_on_transient_error(self) -> None:
+        """Transient HTTP failure increments retries and returns False."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._fetch_status = FetchStatus.SUCCESS
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = False
+
+        mech = _make_mech_info(address="0xtransient", relevant_tools=set())
+        _wire_get_http_response(behaviour, [MagicMock()])
+
+        result = _drive(behaviour.populate_tools([mech]))
+
+        assert result is False
+        assert behaviour._failed_mechs == set()
+        api.increment_retries.assert_called_once()
+        api.reset_retries.assert_not_called()
+        behaviour.context.logger.warning.assert_called()
+
+    def test_quarantines_on_retries_exhausted(self) -> None:
+        """Transient mech whose retries are exhausted is added to _failed_mechs."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = True
 
         mech = _make_mech_info(address="0xbroken", relevant_tools=set())
+        _wire_get_http_response(behaviour, [MagicMock()])
 
-        def mock_fetch_mechs_info():
-            behaviour._fetch_status = FetchStatus.SUCCESS
-            yield
-            return [mech]
+        result = _drive(behaviour.populate_tools([mech]))
 
-        behaviour.fetch_mechs_info = mock_fetch_mechs_info
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_retries_exceeded.return_value = True
-        mock_api.is_permanent_error.return_value = False
-        mock_api.url = "http://test/broken"
-        behaviour._context.mech_tools = mock_api
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
-
-        result = _drive(behaviour.get_mechs_info())
-
-        assert result is None
+        assert result is False
         assert "0xbroken" in behaviour._failed_mechs
+        api.reset_retries.assert_called_once()
+        behaviour.context.logger.error.assert_called()
 
-    def test_clean_up_clears_failed_mechs(self) -> None:
-        """clean_up resets the per-round quarantine set."""
+    def test_quarantines_on_empty_tools(self) -> None:
+        """Empty tools list is deterministic per-CID; mech is quarantined."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._failed_mechs = {"0xbroken"}
-        mock_api = MagicMock()
-        behaviour._context.mech_tools = mock_api
+        api = _setup_api(behaviour)
+        api.process_response.return_value = []
 
-        behaviour.clean_up()
+        mech = _make_mech_info(address="0xempty", relevant_tools=set())
+        _wire_get_http_response(behaviour, [MagicMock()])
 
-        assert behaviour._failed_mechs == set()
-        mock_api.reset_retries.assert_called_once()
+        result = _drive(behaviour.populate_tools([mech]))
+
+        assert result is True
+        assert "0xempty" in behaviour._failed_mechs
+        assert mech.relevant_tools == set()
+        warnings = behaviour.context.logger.warning.call_args_list
+        assert any("empty" in str(call) for call in warnings)
+        api.reset_retries.assert_called_once()
 
 
 class TestPermanentErrorClassification:
@@ -502,119 +234,227 @@ class TestPermanentErrorClassification:
     def test_permanent_error_quarantines_without_incrementing_retries(self) -> None:
         """Permanent classification skips the retry counter entirely."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_permanent_error.return_value = True
-        mock_api.url = "http://test/permanent-cid"
-        behaviour._context.mech_tools = mock_api
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_permanent_error.return_value = True
 
         mech = _make_mech_info(address="0xpermanent", relevant_tools=set())
 
         http_message = MagicMock()
         http_message.status_code = 500
-        _install_fake_parallel_fetch(behaviour, [http_message])
-
-        result = _drive(behaviour.populate_tools([mech]))
-
-        assert result is True  # quarantined; nothing more to do
-        assert "0xpermanent" in behaviour._failed_mechs
-        mock_api.increment_retries.assert_not_called()
-        mock_api.reset_retries.assert_called_once()
-        mock_api.is_permanent_error.assert_called_once_with(http_message)
-        error_calls = behaviour.context.logger.error.call_args_list
-        assert any("permanent content error" in str(call) for call in error_calls)
-
-    def test_transient_error_still_increments_retries_and_does_not_quarantine(
-        self,
-    ) -> None:
-        """Transient path keeps the existing retry semantics."""
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_permanent_error.return_value = False
-        mock_api.is_retries_exceeded.return_value = False
-        mock_api.url = "http://test/transient"
-        behaviour._context.mech_tools = mock_api
-
-        mech = _make_mech_info(address="0xtransient", relevant_tools=set())
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
+        _wire_get_http_response(behaviour, [http_message])
 
         result = _drive(behaviour.populate_tools([mech]))
 
         assert result is False
-        assert behaviour._failed_mechs == set()
-        mock_api.increment_retries.assert_called_once()
-        mock_api.reset_retries.assert_not_called()
+        assert "0xpermanent" in behaviour._failed_mechs
+        api.increment_retries.assert_not_called()
+        api.reset_retries.assert_called_once()
+        api.is_permanent_error.assert_called_once_with(http_message)
+        errors = behaviour.context.logger.error.call_args_list
+        assert any("permanent content error" in str(call) for call in errors)
 
     def test_transient_then_permanent_resets_retries_on_quarantine(self) -> None:
-        """Retry counter bumped on transient call, cleared on permanent quarantine.
-
-        Pins the cross-batch bookkeeping: a prior transient increments the
-        counter, and the later permanent quarantine triggers the end-of-pass
-        reset so a requeued / next-period fetch starts clean.
-        """
+        """Retry counter bumped on transient call, cleared on permanent quarantine."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        mock_api.process_response.return_value = None
-        mock_api.is_retries_exceeded.return_value = False
-        mock_api.url = "http://test/flaky-then-permanent"
-        behaviour._context.mech_tools = mock_api
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_retries_exceeded.return_value = False
 
         mech = _make_mech_info(address="0xflaky", relevant_tools=set())
 
         # Call 1: transient — increment_retries, no quarantine, no reset.
-        mock_api.is_permanent_error.return_value = False
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
+        api.is_permanent_error.return_value = False
+        _wire_get_http_response(behaviour, [MagicMock()])
         _drive(behaviour.populate_tools([mech]))
         assert "0xflaky" not in behaviour._failed_mechs
-        mock_api.increment_retries.assert_called_once()
-        mock_api.reset_retries.assert_not_called()
+        api.increment_retries.assert_called_once()
+        api.reset_retries.assert_not_called()
 
         # Call 2: gateway flips to a permanent body on the same mech.
-        mock_api.is_permanent_error.return_value = True
-        _install_fake_parallel_fetch(behaviour, [MagicMock()])
+        api.is_permanent_error.return_value = True
+        _wire_get_http_response(behaviour, [MagicMock()])
         _drive(behaviour.populate_tools([mech]))
         assert "0xflaky" in behaviour._failed_mechs
-        # increment_retries still only fired once (the first, transient call).
-        mock_api.increment_retries.assert_called_once()
-        # reset_retries must be called by end-of-pass logic in the permanent
-        # branch so the next fetch period starts with a clean counter.
-        mock_api.reset_retries.assert_called_once()
+        api.increment_retries.assert_called_once()  # still only the first call
+        api.reset_retries.assert_called_once()  # the permanent branch resets
 
-    def test_get_mechs_info_permanent_error_needs_only_one_http_call(self) -> None:
-        """Permanent broken mech quarantined on first attempt.
 
-        Before Fix 2 the broken mech would consume 6 attempts before
-        quarantine. Fix 2 made it 1 attempt. Fix 4 (this change) runs
-        the good + broken fetches in parallel, so total wall time =
-        max(per-mech) instead of sum. Asserts one parallel pass, two
-        HTTP sends.
-        """
+class TestCidGrouping:
+    """Tests for CID-coalesced fetching in populate_tools.
+
+    Mechs that share a metadata CID resolve to the same IPFS manifest, so
+    the populate loop coalesces them into a single fetch and broadcasts the
+    result to every mech in the group.
+    """
+
+    def test_shared_cid_fetched_once_for_all_mechs(self) -> None:
+        """N mechs with identical metadata_str result in a single HTTP fetch."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._fetch_status = FetchStatus.SUCCESS
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
+        api = _setup_api(behaviour)
+        api.process_response.return_value = ["tool_x", "tool_y"]
+
+        mechs = [
+            _make_mech_info(
+                address=f"0x{i}", metadata_str="shared", relevant_tools=set()
+            )
+            for i in range(4)
+        ]
+
+        call_count = {"n": 0}
+
+        def mock_get_http_response(**kwargs):
+            call_count["n"] += 1
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is True
+        assert call_count["n"] == 1  # one fetch, not four
+        for mech in mechs:
+            assert mech.relevant_tools == {"tool_x", "tool_y"}
+
+    def test_distinct_cids_fetched_separately(self) -> None:
+        """Each distinct CID gets its own HTTP fetch."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.side_effect = [["tool_a"], ["tool_b"]]
+
+        mech_a = _make_mech_info(
+            address="0xa", metadata_str="aaa", relevant_tools=set()
+        )
+        mech_b = _make_mech_info(
+            address="0xb", metadata_str="bbb", relevant_tools=set()
+        )
+
+        call_count = {"n": 0}
+
+        def mock_get_http_response(**kwargs):
+            call_count["n"] += 1
+            yield
+            return MagicMock()
+
+        behaviour.get_http_response = mock_get_http_response
+
+        result = _drive(behaviour.populate_tools([mech_a, mech_b]))
+
+        assert result is True
+        assert call_count["n"] == 2
+        assert mech_a.relevant_tools == {"tool_a"}
+        assert mech_b.relevant_tools == {"tool_b"}
+
+    def test_permanent_error_quarantines_all_mechs_in_group(self) -> None:
+        """Permanent error on a CID quarantines every mech sharing that CID."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_permanent_error.return_value = True
+
+        mechs = [
+            _make_mech_info(address=f"0x{i}", metadata_str="bad", relevant_tools=set())
+            for i in range(3)
+        ]
+
+        http_message = MagicMock()
+        http_message.status_code = 404
+        _wire_get_http_response(behaviour, [http_message])
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is False
+        for mech in mechs:
+            assert mech.address in behaviour._failed_mechs
+        api.increment_retries.assert_not_called()
+
+    def test_empty_tools_quarantines_all_mechs_in_group(self) -> None:
+        """Empty manifest on a shared CID quarantines every mech in the group."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.return_value = []
+
+        mechs = [
+            _make_mech_info(
+                address=f"0x{i}", metadata_str="empty", relevant_tools=set()
+            )
+            for i in range(3)
+        ]
+
+        _wire_get_http_response(behaviour, [MagicMock()])
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is True
+        for mech in mechs:
+            assert mech.address in behaviour._failed_mechs
+
+    def test_retries_exhausted_quarantines_all_mechs_in_group(self) -> None:
+        """Retries-exhausted on a shared CID quarantines every mech in the group."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
+        api.is_permanent_error.return_value = False
+        api.is_retries_exceeded.return_value = True
+
+        mechs = [
+            _make_mech_info(
+                address=f"0x{i}", metadata_str="flaky", relevant_tools=set()
+            )
+            for i in range(3)
+        ]
+
+        _wire_get_http_response(behaviour, [MagicMock()])
+
+        result = _drive(behaviour.populate_tools(mechs))
+
+        assert result is False
+        for mech in mechs:
+            assert mech.address in behaviour._failed_mechs
+        api.reset_retries.assert_called_once()
+
+
+class TestGetMechsInfo:
+    """Tests for the get_mechs_info generator method."""
+
+    def test_returns_none_on_fetch_failure(self) -> None:
+        """Returns None when fetch_mechs_info doesn't reach SUCCESS state."""
+        behaviour = _make_mech_info_behaviour()
+        behaviour._fetch_status = FetchStatus.IN_PROGRESS
+
+        def mock_fetch_mechs_info():
+            yield
+            return []
+
+        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+
+        result = _drive(behaviour.get_mechs_info())
+
+        assert result is None
+
+    def test_returns_none_on_empty_info(self) -> None:
+        """Returns None when mech info is empty."""
+        behaviour = _make_mech_info_behaviour()
+
+        def mock_fetch_mechs_info():
+            behaviour._fetch_status = FetchStatus.SUCCESS
+            yield
+            return []
+
+        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+
+        result = _drive(behaviour.get_mechs_info())
+
+        assert result is None
+
+    def test_partial_success_returns_serialized_json(self) -> None:
+        """One good mech + one broken mech returns JSON; broken has empty tools."""
+        behaviour = _make_mech_info_behaviour()
+        api = _setup_api(behaviour)
+        api.process_response.side_effect = [["tool_good"], None]
+        api.is_permanent_error.return_value = True
+        api.url = "http://test/broken"
 
         good = _make_mech_info(
             address="0xgood", metadata_str="good", relevant_tools=set()
@@ -629,30 +469,7 @@ class TestPermanentErrorClassification:
             return [good, broken]
 
         behaviour.fetch_mechs_info = mock_fetch_mechs_info
-
-        mock_api = MagicMock()
-        mock_api.__dict__["_frozen"] = True
-        mock_api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        # pending order is [good, broken]; mock returns in that order.
-        # URL-keyed dispatch can't work here: the parallel design snapshots
-        # all specs upfront, so by the time process_response runs the api's
-        # mutable .url is fixed at the last (broken) mech's URL.
-        mock_api.process_response.side_effect = [["tool_good"], None]
-        mock_api.is_permanent_error.return_value = True
-        mock_api.url = "http://test/broken"
-        behaviour._context.mech_tools = mock_api
-
-        parallel_call_count = {"n": 0}
-        total_requests = {"n": 0}
-
-        def _fake_fetch(specs, timeout, poll_interval=0.1):
-            parallel_call_count["n"] += 1
-            total_requests["n"] += len(specs)
-            yield
-            # good first, broken second (per pending order)
-            return [MagicMock(), MagicMock()]
-
-        behaviour._fetch_http_parallel = _fake_fetch
+        _wire_get_http_response(behaviour, [MagicMock(), MagicMock()])
 
         result = _drive(behaviour.get_mechs_info())
 
@@ -662,440 +479,42 @@ class TestPermanentErrorClassification:
         assert good.relevant_tools == {"tool_good"}
         assert broken.relevant_tools == set()
         assert "0xbroken" in behaviour._failed_mechs
-        # One parallel pass, two total HTTP sends (one per mech).
-        # Without the classifier this would be 7 (1 good + 6 broken retries).
-        assert parallel_call_count["n"] == 1
-        assert total_requests["n"] == 2
-        mock_api.increment_retries.assert_not_called()
 
-
-def _drive(gen):
-    """Run a generator to StopIteration, returning its .value."""
-    try:
-        while True:
-            next(gen)
-    except StopIteration as e:
-        return e.value
-
-
-def _step(gen):
-    """Advance a generator one yield; return True if still running."""
-    try:
-        next(gen)
-        return True
-    except StopIteration:
-        return False
-
-
-class TestFetchHttpParallel:
-    """Unit tests for MechInformationBehaviour._fetch_http_parallel."""
-
-    def _install_build_helpers(self, behaviour, nonces):
-        """Wire _build_http_request_message + _get_request_nonce_from_dialogue.
-
-        Returns a list of the dialogues so tests can introspect.
-        """
-        dialogues = []
-        build_calls = []
-
-        def build(**kwargs):
-            idx = len(build_calls)
-            build_calls.append(kwargs)
-            msg = MagicMock(name=f"msg-{idx}")
-            dlg = MagicMock(name=f"dlg-{idx}")
-            dlg._parallel_nonce = nonces[idx]
-            dialogues.append(dlg)
-            return msg, dlg
-
-        behaviour._build_http_request_message = build
-        behaviour._get_request_nonce_from_dialogue = lambda d: d._parallel_nonce
-        behaviour._build_calls = build_calls
-        return dialogues
-
-    def _install_counting_sleep(self, behaviour):
-        """Replace self.sleep with a counting generator yielding once."""
-        sleep_calls = []
-
-        def sleep(seconds):
-            sleep_calls.append(seconds)
-            yield
-
-        behaviour.sleep = sleep
-        behaviour._sleep_calls = sleep_calls
-
-    def test_fan_out_sends_all_messages_before_any_sleep(self) -> None:
-        """A1: put_message is called N times before the first sleep fires."""
-        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
-        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
-        self._install_counting_sleep(behaviour)
-
-        gen = behaviour._fetch_http_parallel(
-            [
-                {"method": "GET", "url": "u1"},
-                {"method": "GET", "url": "u2"},
-                {"method": "GET", "url": "u3"},
-            ],
-            timeout=10.0,
-        )
-        # Drive just to the first yield (first sleep call).
-        _step(gen)
-
-        assert behaviour._context.outbox.put_message.call_count == 3
-        assert len(behaviour._sleep_calls) == 1
-        # All three callbacks registered before the first sleep.
-        registry = behaviour._context.requests.request_id_to_callback
-        assert set(registry.keys()) == {"n1", "n2", "n3"}
-
-    def test_responses_returned_in_input_order(self) -> None:
-        """A2: output order matches input order, not arrival order."""
-        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
-        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
-        self._install_counting_sleep(behaviour)
-
-        registry = behaviour._context.requests.request_id_to_callback
-        gen = behaviour._fetch_http_parallel(
-            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=10.0
-        )
-        _step(gen)  # fan-out done; first sleep yielded
-
-        msg1, msg2, msg3 = (
-            MagicMock(name="m1"),
-            MagicMock(name="m2"),
-            MagicMock(name="m3"),
-        )
-        # Fire in reverse arrival order.
-        registry["n2"](msg2, behaviour)
-        registry["n3"](msg3, behaviour)
-        registry["n1"](msg1, behaviour)
-
-        result = _drive(gen)
-        assert result == [msg1, msg2, msg3]
-
-    def test_timed_out_entries_are_none(self) -> None:
-        """A3: timeout yields None for unresponded requests."""
-        behaviour = _wire_parallel_fetch(
-            _make_mech_info_behaviour(),
-            # _clock() is called at deadline-setup then on each loop iteration.
-            clock_values=[0.0, 0.05, 100.0],
-        )
-        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
-        self._install_counting_sleep(behaviour)
-
-        registry = behaviour._context.requests.request_id_to_callback
-        gen = behaviour._fetch_http_parallel(
-            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=1.0
-        )
-        _step(gen)
-
-        msg2 = MagicMock(name="m2")
-        registry["n2"](msg2, behaviour)
-
-        result = _drive(gen)
-        assert result == [None, msg2, None]
-
-    def test_cleanup_pops_unresolved_nonces_from_registry(self) -> None:
-        """A4: on exit, registry is cleared of every nonce we registered."""
-        behaviour = _wire_parallel_fetch(
-            _make_mech_info_behaviour(), clock_values=[0.0, 0.05, 100.0]
-        )
-        self._install_build_helpers(behaviour, ["n1", "n2", "n3"])
-        self._install_counting_sleep(behaviour)
-
-        registry = behaviour._context.requests.request_id_to_callback
-        gen = behaviour._fetch_http_parallel(
-            [{"url": "u1"}, {"url": "u2"}, {"url": "u3"}], timeout=1.0
-        )
-        _step(gen)
-        # No responses; timeout expires.
-        _drive(gen)
-
-        assert "n1" not in registry
-        assert "n2" not in registry
-        assert "n3" not in registry
-
-    def test_cleanup_runs_on_exception(self) -> None:
-        """A5: unresolved nonces popped even when sleep raises."""
-        behaviour = _wire_parallel_fetch(_make_mech_info_behaviour())
-        self._install_build_helpers(behaviour, ["n1", "n2"])
-
-        def boom_sleep(seconds):
-            raise RuntimeError("boom")
-            yield  # pragma: no cover - make it a generator function
-
-        behaviour.sleep = boom_sleep
-        registry = behaviour._context.requests.request_id_to_callback
-
-        gen = behaviour._fetch_http_parallel(
-            [{"url": "u1"}, {"url": "u2"}], timeout=10.0
-        )
-        try:
-            _drive(gen)
-        except RuntimeError:
-            pass
-
-        assert "n1" not in registry
-        assert "n2" not in registry
-
-    def test_custom_callback_writes_to_results_without_touching_behaviour(self) -> None:
-        """A6: _make_parallel_fetch_callback is behaviour-state-agnostic."""
-        from packages.valory.skills.mech_interact_abci.behaviours.mech_info import (
-            _make_parallel_fetch_callback,
-        )
-
-        results: dict = {}
-        cb = _make_parallel_fetch_callback(results, "nX")
-        mock_message = MagicMock()
-        mock_current_behaviour = MagicMock()
-
-        cb(mock_message, mock_current_behaviour)
-
-        assert results["nX"] is mock_message
-        # No calls of any kind on current_behaviour — not try_send, not state.
-        mock_current_behaviour.assert_not_called()
-        assert not mock_current_behaviour.method_calls
-
-
-class TestPopulateToolsParallelSemantics:
-    """Tests for the parallel-batch semantics of populate_tools (Fix 4)."""
-
-    def _setup(self, behaviour, api_side_effects=None):
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-        api = MagicMock()
-        api.__dict__["_frozen"] = True
-        api.get_spec.return_value = {"url": "http://test", "method": "GET"}
-        api.url = "http://test/hash"
-        if api_side_effects is not None:
-            api.process_response.side_effect = api_side_effects
-        behaviour._context.mech_tools = api
-        return api
-
-    def test_mixed_permanent_transient_good_in_one_batch(self) -> None:
-        """B3: three mechs with different outcomes; all handled in one pass."""
+    def test_all_failed_returns_none(self) -> None:
+        """If every mech fails, result is None so the round can retry."""
         behaviour = _make_mech_info_behaviour()
-        api = self._setup(behaviour, api_side_effects=[["tool_x"], None, None])
-        api.is_permanent_error.side_effect = [
-            True,
-            False,
-        ]  # order: permanent, transient
-        api.is_retries_exceeded.return_value = False
-
-        mech_good = _make_mech_info(
-            address="0xgood", metadata_str="good", relevant_tools=set()
-        )
-        mech_permanent = _make_mech_info(
-            address="0xpermanent", metadata_str="permanent", relevant_tools=set()
-        )
-        mech_transient = _make_mech_info(
-            address="0xtransient", metadata_str="transient", relevant_tools=set()
-        )
-
-        perm_response = MagicMock()
-        perm_response.status_code = 500
-        _install_fake_parallel_fetch(
-            behaviour, [MagicMock(), perm_response, MagicMock()]
-        )
-
-        result = _drive(
-            behaviour.populate_tools([mech_good, mech_permanent, mech_transient])
-        )
-
-        assert result is False  # transient still has retries
-        assert mech_good.relevant_tools == {"tool_x"}
-        assert "0xpermanent" in behaviour._failed_mechs
-        assert "0xtransient" not in behaviour._failed_mechs
-        # Single increment for the batch, not per-mech.
-        api.increment_retries.assert_called_once()
-
-    def test_all_transient_batch_advances_shared_counter_once(self) -> None:
-        """B4: shared retry counter advances once per pass, not per mech."""
-        behaviour = _make_mech_info_behaviour()
-        api = self._setup(behaviour, api_side_effects=[None, None, None])
-        api.is_permanent_error.return_value = False
-        api.is_retries_exceeded.return_value = False
-
-        mechs = [
-            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
-            for i in range(3)
-        ]
-        _install_fake_parallel_fetch(behaviour, [MagicMock()] * 3)
-
-        result = _drive(behaviour.populate_tools(mechs))
-
-        assert result is False
-        assert behaviour._failed_mechs == set()
-        # Three transient failures in one pass -> ONE counter advance, not three.
-        assert api.increment_retries.call_count == 1
-
-    def test_retries_exhausted_during_batch_quarantines_all_pending(self) -> None:
-        """B5: on retries exhaustion, quarantine every still-unpopulated mech."""
-        behaviour = _make_mech_info_behaviour()
-        api = self._setup(behaviour, api_side_effects=[None, None, None])
+        api = _setup_api(behaviour)
+        api.process_response.return_value = None
         api.is_permanent_error.return_value = False
         api.is_retries_exceeded.return_value = True
 
-        mechs = [
-            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
-            for i in range(3)
-        ]
-        _install_fake_parallel_fetch(behaviour, [MagicMock()] * 3)
+        mech = _make_mech_info(address="0xbroken", relevant_tools=set())
 
-        result = _drive(behaviour.populate_tools(mechs))
-
-        assert result is True  # every mech quarantined; no more work
-        for i in range(3):
-            assert f"0x{i}" in behaviour._failed_mechs
-        api.reset_retries.assert_called_once()
-
-    def test_timed_out_fetch_is_treated_as_transient(self) -> None:
-        """B6: None response (timeout) increments retries; no quarantine."""
-        behaviour = _make_mech_info_behaviour()
-        api = self._setup(behaviour)
-        api.is_permanent_error.return_value = False
-        api.is_retries_exceeded.return_value = False
-
-        mechs = [
-            _make_mech_info(address=f"0x{i}", metadata_str=str(i), relevant_tools=set())
-            for i in range(3)
-        ]
-        _install_fake_parallel_fetch(behaviour, [None, None, None])
-
-        result = _drive(behaviour.populate_tools(mechs))
-
-        assert result is False
-        assert behaviour._failed_mechs == set()
-        api.increment_retries.assert_called_once()
-
-    def test_zero_pending_mechs_returns_true_without_fetching(self) -> None:
-        """B2: all mechs pre-populated — no fetch, no put_message."""
-        behaviour = _make_mech_info_behaviour()
-        self._setup(behaviour)
-
-        mechs = [
-            _make_mech_info(address="0xm1", relevant_tools={"already"}),
-            _make_mech_info(address="0xm2", relevant_tools={"here"}),
-        ]
-
-        fetch_calls = []
-
-        def _fake_fetch(specs, timeout, poll_interval=0.1):
-            fetch_calls.append(specs)
+        def mock_fetch_mechs_info():
+            behaviour._fetch_status = FetchStatus.SUCCESS
             yield
-            return [MagicMock() for _ in specs]
+            return [mech]
 
-        behaviour._fetch_http_parallel = _fake_fetch
+        behaviour.fetch_mechs_info = mock_fetch_mechs_info
+        _wire_get_http_response(behaviour, [MagicMock()])
 
-        result = _drive(behaviour.populate_tools(mechs))
+        result = _drive(behaviour.get_mechs_info())
 
-        assert result is True
-        assert fetch_calls == []
+        assert result is None
+        assert "0xbroken" in behaviour._failed_mechs
 
-    def test_specs_snapshotted_per_mech(self) -> None:
-        """B1: each mech's spec is snapshotted before the next mech's URL mutation."""
+
+class TestCleanUp:
+    """Tests for clean_up."""
+
+    def test_clean_up_clears_failed_mechs_and_resets_retries(self) -> None:
+        """clean_up resets the per-round quarantine set and the retry counter."""
         behaviour = _make_mech_info_behaviour()
-        behaviour._context.params = MagicMock()
-        behaviour._context.params.ipfs_address = "https://ipfs.io/"
-        behaviour._context.params.irrelevant_tools = set()
-        behaviour._context.params.mech_tools_parallel_timeout = 10.0
-
-        # Real ApiSpecs-style url mutation via set_mech_agent_specs.
+        behaviour._failed_mechs = {"0xbroken"}
         api = MagicMock()
-        api.__dict__["_frozen"] = True
-        api.is_permanent_error.return_value = False
-        api.is_retries_exceeded.return_value = False
-        api.process_response.side_effect = [["tool_a"], ["tool_b"]]
-        # get_spec returns the current URL at the time of the call.
-        api.get_spec = lambda: {"url": api.url, "method": "GET"}
         behaviour._context.mech_tools = api
 
-        mech_a = _make_mech_info(
-            address="0xa", metadata_str="aaa", relevant_tools=set()
-        )
-        mech_b = _make_mech_info(
-            address="0xb", metadata_str="bbb", relevant_tools=set()
-        )
+        behaviour.clean_up()
 
-        captured_specs = []
-
-        def _fake_fetch(specs, timeout, poll_interval=0.1):
-            captured_specs.extend(specs)
-            yield
-            return [MagicMock(), MagicMock()]
-
-        behaviour._fetch_http_parallel = _fake_fetch
-
-        _drive(behaviour.populate_tools([mech_a, mech_b]))
-
-        # Each spec must carry its own mech's CID, not the last-mutated URL.
-        assert CID_PREFIX + "aaa" in captured_specs[0]["url"]
-        assert CID_PREFIX + "bbb" in captured_specs[1]["url"]
-
-    def test_primitive_wall_time_scales_with_max_not_sum_of_latencies(self) -> None:
-        """_fetch_http_parallel elapsed time tracks max(latencies), not sum.
-
-        Drives the real primitive with a simulated clock and callback
-        dispatcher: 5 requests with staggered arrival latencies
-        (50, 100, 150, 200, 500 ms). A sequential implementation would need
-        sum = 1000 ms of simulated time to complete; the parallel primitive
-        completes at max = 500 ms plus at most one poll_interval of slop.
-
-        The `elapsed < sum` assertion is the falsifiability point — it fails
-        for any serialized implementation.
-        """
-        # Reuse the TestFetchHttpParallel class's build helper by hand.
-        behaviour = _make_mech_info_behaviour()
-        behaviour._context.outbox = MagicMock()
-        behaviour._context.requests = MagicMock()
-        registry: dict = {}
-        behaviour._context.requests.request_id_to_callback = registry
-
-        nonces = [f"n{i}" for i in range(5)]
-        build_calls: list = []
-
-        def build(**kwargs):
-            idx = len(build_calls)
-            build_calls.append(kwargs)
-            msg = MagicMock(name=f"msg-{idx}")
-            dlg = MagicMock(name=f"dlg-{idx}")
-            dlg._parallel_nonce = nonces[idx]
-            return msg, dlg
-
-        behaviour._build_http_request_message = build
-        behaviour._get_request_nonce_from_dialogue = lambda d: d._parallel_nonce
-
-        latencies_ms = [50, 100, 150, 200, 500]
-        scheduled = {nonces[i]: latencies_ms[i] / 1000.0 for i in range(5)}
-        poll_interval = 0.1
-
-        current_time = [0.0]
-        behaviour._clock = lambda: current_time[0]
-
-        def fake_sleep(seconds):
-            current_time[0] += seconds
-            # Fire callbacks whose scheduled arrival has been reached.
-            for nonce in list(scheduled):
-                if scheduled[nonce] <= current_time[0] and nonce in registry:
-                    registry[nonce](MagicMock(name=nonce), behaviour)
-                    del scheduled[nonce]
-            yield
-
-        behaviour.sleep = fake_sleep
-
-        gen = behaviour._fetch_http_parallel(
-            [{"url": f"u{i}"} for i in range(5)],
-            timeout=10.0,
-            poll_interval=poll_interval,
-        )
-        result = _drive(gen)
-
-        assert all(r is not None for r in result)
-
-        max_lat = max(latencies_ms) / 1000.0  # 0.5s
-        sum_lat = sum(latencies_ms) / 1000.0  # 1.0s
-
-        # Elapsed tracks max, bounded by max + one poll_interval of slop.
-        assert current_time[0] <= max_lat + poll_interval * 1.5
-        # Falsifiability: sequential code needs sum_lat; parallel needs max_lat.
-        assert current_time[0] < sum_lat
+        assert behaviour._failed_mechs == set()
+        api.reset_retries.assert_called_once()


### PR DESCRIPTION
## Summary

Reverts the parallel `populate_tools` path introduced in #69 and replaces the lost throughput recovery with **per-CID coalescing**.

A trader running mech-interact v0.26.0 inside Pearl wedged silently inside `mech_information_round` on Omen (4 mechs sharing one metadata CID — `0x157d3b10…`). Reverting the trader to v0.25.0 (pre-#69) restored normal operation. v0.26.0's only silent code path is #69's `_fetch_http_parallel` custom-callback dispatch, so the regression localizes there.

## Why parallelize was speculative

#67's motivation was a hypothetical N-broken-mechs ceiling. The actually-observed worst case in production was a single broken mech (~2.1s sequentially). #68's permanent-error classifier already collapses broken-mech cost to one RTT, so the realistic ceiling sits around ~75 simultaneously-broken mechs in the 30s round budget — a scenario we have never seen in the wild. The parallel path is not worth the framework-integration complexity it introduced (custom-callback dispatch bypassing `get_callback_request`/`try_send`, behaviour staying in `RUNNING` instead of `WAITING_MESSAGE`, late-response cleanup race that can raise `ABCIAppInternalError → process crash` under `stop_and_exit`).

## What this PR does

1. **Restores the sequential `get_http_response` loop** in `populate_tools`. This is the framework-integrated path that worked in v0.25.0.
2. **Adds per-CID coalescing** as #69's proper successor: pending mechs are grouped by `mech.service.metadata_str` and fetched once per distinct CID. The resulting tool set is broadcast to every mech in the group. Omen's 4-identical-CIDs case collapses to **1 fetch** (vs 4 sequential or 4 parallel) — strictly fewer network calls than either prior approach.
3. **Preserves all quarantine + retry semantics** from #66 and #68:
   - Permanent errors (4xx, 5xx with marker) → immediate group-wide quarantine, no retries
   - Transient retries-exhausted → group-wide quarantine after retry budget
   - Empty manifests (deterministic per-CID) → group-wide quarantine
4. **Drops `mech_tools_parallel_timeout`** from `MechParams` and `skill.yaml`.
5. **Replaces** `TestFetchHttpParallel` and `TestPopulateToolsParallelSemantics` with sequential + CID-grouping coverage.

## Test plan

- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests -rfE` — 356 passed.
- [x] `uv run tomte check-code` — all 6 linters green (black, isort, flake8, mypy, pylint, darglint).
- [x] `make generators` — skill hash regenerated; `packages.json` updated.
- [x] **Manual verification of the Omen 4-identical-CIDs case in test** — `TestCidGrouping.test_shared_cid_fetched_once_for_all_mechs` asserts 4 mechs sharing a CID result in exactly 1 HTTP fetch.

## Notes

- This restores semantics that were live-validated in v0.25.0; the trader has already been pinned to v0.25.0 in Pearl, so this brings `main` back in line with what's shipped.
- For the production hang report and root-cause analysis, see `MECH_INFORMATION_HANG_REPORT.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)