### PR TITLE
fix(request): pass approval bytes to MultisendBatch unchanged

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeifip7e6al6nwtwbyqol4xm2iqnuycrdefdie7vyxlxeh33ubqeooa",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeie267gridf6z2yxk7cvt5fdy66cocyg5dn3rj7zvnvl3otnk6iw34",
         "contract/valory/subscription_provider/0.1.0": "bafybeibulnegkf7jsz4lrhvsvai65wytjspl6itkhb6dhbl3fwsbpbyh6u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiaczcber6tmw4rrlbislsksahpj4wmnhyeg5tgxumkxhm3dzjxhqu"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibzmqjyggvnvbuutmk2a7ju7cfdydj3qthenhojcf6olwweuhu6oy"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeifip7e6al6nwtwbyqol4xm2iqnuycrdefdie7vyxlxeh33ubqeooa",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeie267gridf6z2yxk7cvt5fdy66cocyg5dn3rj7zvnvl3otnk6iw34",
         "contract/valory/subscription_provider/0.1.0": "bafybeibulnegkf7jsz4lrhvsvai65wytjspl6itkhb6dhbl3fwsbpbyh6u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeihazofcrox6qvvxojxm4t7ezic4llxwvleoalfk67vqdevukwy3zi"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiaczcber6tmw4rrlbislsksahpj4wmnhyeg5tgxumkxhm3dzjxhqu"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/behaviours/request.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/request.py
@@ -114,7 +114,7 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
         self._subscription_address: Optional[str] = None
         self._subscription_id: Optional[int] = None
         self._balance_tracker: Optional[str] = None
-        self._approval_data: Optional[str] = None
+        self._approval_data: Optional[bytes] = None
 
     @property
     def metadata_filepath(self) -> str:
@@ -253,7 +253,7 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
         return self._balance_tracker
 
     @property
-    def approval_data(self) -> Optional[str]:
+    def approval_data(self) -> Optional[bytes]:
         """Get the approval data."""
         if self._approval_data is None:
             self.context.logger.warning(
@@ -743,7 +743,7 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
             )
         )
 
-    def _approve_balance_tracker(self) -> WaitableConditionType:  # pragma: no cover
+    def _approve_balance_tracker(self) -> WaitableConditionType:
         """Build approval for the balance tracker."""
         self.context.logger.info("Building approval for token payment.")
 
@@ -761,7 +761,7 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
             )
         )
 
-    def _build_token_approval(self) -> WaitableConditionType:  # pragma: no cover
+    def _build_token_approval(self) -> WaitableConditionType:
         """Get the balance tracker, build approval for the token payment and add it to the multisend batch."""
         if not self._balance_tracker:
             status = yield from self._get_balance_tracker()
@@ -776,9 +776,7 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
 
         batch = MultisendBatch(
             to=self.params.price_token,
-            data=bytes.fromhex(
-                self.approval_data.removeprefix("0x").removeprefix("0X")
-            ),
+            data=self.approval_data,
         )
         self.multisend_batches.append(batch)
         self.context.logger.info("Successfully built approval data.")

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   behaviours/mech_info.py: bafybeidleagib3fzbtehwotw54isgtc3kdwuvhxq3e3icccvky7cixzywy
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeigbd652kkbd4q42za3mn26ixnb5te6yu3ms5dr54w5h4oqov4pxya
-  behaviours/request.py: bafybeia2c4ms6vya5kqae4qxi3tc3pe4dw2pmo5mxvu4ewrtz7av5e7gwy
+  behaviours/request.py: bafybeifaulssfqbxex7mnjzpdmggwdw3zk7fowgxn4e4b2gcnpq6s4ovcq
   behaviours/response.py: bafybeidzrk4ghsbley3mizsevexmr3ghvu4qih4whaysskjzws5i35junu
   behaviours/round_behaviour.py: bafybeige7ajovc2u3vjb2elodqi47urfb5nms4felsx4b7jb3zaorimjv4
   dialogues.py: bafybeiachjgarkgv4hxprddn7dtb5h3q4qge72rc2kysmureooq5xggxxi
@@ -42,7 +42,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeicg4rgbj6touygc5v64jdl6h4vligldqb4rfhmnunksnbmytstp5u
   tests/behaviours/test_mech_version.py: bafybeicuapex7burjwnxrq2lhoihtgyp6i64mkcdigtjihutwvjrbt5w3q
   tests/behaviours/test_purchase_subscription.py: bafybeiapngvvm26wtzc4iszts3wkj6duvchucyuylvrvsealvbpnpiw36m
-  tests/behaviours/test_request.py: bafybeigdarzspbchpuuepfrp6jok6ysvywmuqgisobwdpk67ass4tm535m
+  tests/behaviours/test_request.py: bafybeidm733k72klsn4cqmtqe27ft24kwfxgffjxqswiclbf66ojztifmm
   tests/behaviours/test_response.py: bafybeigxuosfyhqfucq2gferbo4xejfs6a4v3skoes342lfnr7r5xmhowq
   tests/states/__init__.py: bafybeieo3txynlsaxtuqxvvhjyjn2hft3ztsnr5v6byoccqg2allecx2vm
   tests/states/test_base.py: bafybeicsbnsusb2xrsnduc2uxm4l45nhogblzzhtek7no4ooty5ionukva

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -42,7 +42,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeicg4rgbj6touygc5v64jdl6h4vligldqb4rfhmnunksnbmytstp5u
   tests/behaviours/test_mech_version.py: bafybeicuapex7burjwnxrq2lhoihtgyp6i64mkcdigtjihutwvjrbt5w3q
   tests/behaviours/test_purchase_subscription.py: bafybeiapngvvm26wtzc4iszts3wkj6duvchucyuylvrvsealvbpnpiw36m
-  tests/behaviours/test_request.py: bafybeidm733k72klsn4cqmtqe27ft24kwfxgffjxqswiclbf66ojztifmm
+  tests/behaviours/test_request.py: bafybeicwskajjowt4lxttaxv6ciskdpvzzfbuzzgu45htfyf3msuoygvcm
   tests/behaviours/test_response.py: bafybeigxuosfyhqfucq2gferbo4xejfs6a4v3skoes342lfnr7r5xmhowq
   tests/states/__init__.py: bafybeieo3txynlsaxtuqxvvhjyjn2hft3ztsnr5v6byoccqg2allecx2vm
   tests/states/test_base.py: bafybeicsbnsusb2xrsnduc2uxm4l45nhogblzzhtek7no4ooty5ionukva

--- a/packages/valory/skills/mech_interact_abci/tests/behaviours/test_request.py
+++ b/packages/valory/skills/mech_interact_abci/tests/behaviours/test_request.py
@@ -21,6 +21,8 @@
 
 import pytest
 
+from packages.valory.contracts.erc20.contract import ERC20TokenContract
+from packages.valory.protocols.contract_api import ContractApiMessage
 from packages.valory.skills.mech_interact_abci.behaviours.request import (
     DECIMALS_6,
     DECIMALS_18,
@@ -32,6 +34,15 @@ from packages.valory.skills.mech_interact_abci.behaviours.request import (
 from packages.valory.skills.mech_interact_abci.tests.behaviours.conftest import (
     assert_unset_property_logs,
 )
+
+
+def _drive_generator(gen):
+    """Drive a generator until it returns, ignoring yielded values."""
+    try:
+        while True:
+            next(gen)
+    except StopIteration as e:
+        return e.value
 
 
 class TestPaymentType:
@@ -232,3 +243,172 @@ class TestDecodeHexToBytes:
         result = request_behaviour._decode_hex_to_bytes("0xZZZZ", "t")
         assert result is None
         request_behaviour.context.logger.error.assert_called_once()
+
+
+def _gen_returning(value):
+    """Build a generator-function that yields once and returns ``value``."""
+
+    def _g(*_args, **_kwargs):
+        yield
+        return value
+
+    return _g
+
+
+class TestApproveBalanceTracker:
+    """Tests for _approve_balance_tracker (thin wrapper around contract_interact)."""
+
+    def _setup(self, request_behaviour, *, return_value=True):
+        captured = {}
+
+        def mock_contract_interact(**kwargs):
+            captured.update(kwargs)
+            yield
+            return return_value
+
+        request_behaviour.contract_interact = mock_contract_interact
+        request_behaviour._balance_tracker = "0xtracker"
+        request_behaviour._mech_max_delivery_rate = 1234
+        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour.context.params.mech_chain_id = 100
+        return captured
+
+    def test_calls_contract_interact_with_correct_kwargs(
+        self, request_behaviour
+    ) -> None:
+        """Verify every kwarg passed to contract_interact matches the ERC20 approve call."""
+        captured = self._setup(request_behaviour)
+
+        result = _drive_generator(request_behaviour._approve_balance_tracker())
+
+        assert result is True
+        assert (
+            captured["performative"]
+            == ContractApiMessage.Performative.GET_RAW_TRANSACTION
+        )
+        assert captured["contract_address"] == "0xtoken"
+        assert captured["contract_public_id"] == ERC20TokenContract.contract_id
+        assert captured["contract_callable"] == "build_approval_tx"
+        assert captured["data_key"] == "data"
+        assert captured["placeholder"] == "_approval_data"
+        assert captured["spender"] == "0xtracker"
+        assert captured["amount"] == 1234
+        assert captured["chain_id"] == 100
+
+    def test_propagates_failure_from_contract_interact(self, request_behaviour) -> None:
+        """A False from contract_interact propagates back unchanged."""
+        self._setup(request_behaviour, return_value=False)
+        result = _drive_generator(request_behaviour._approve_balance_tracker())
+        assert result is False
+
+    def test_logs_info_on_invocation(self, request_behaviour) -> None:
+        """The behaviour announces that it is building the approval."""
+        self._setup(request_behaviour)
+        _drive_generator(request_behaviour._approve_balance_tracker())
+        request_behaviour.context.logger.info.assert_called_once_with(
+            "Building approval for token payment."
+        )
+
+
+class TestBuildTokenApproval:
+    """Tests for _build_token_approval orchestration and batch construction."""
+
+    def test_appends_multisend_batch_with_approval_bytes(
+        self, request_behaviour
+    ) -> None:
+        """Approval bytes are passed through to MultisendBatch.data unchanged.
+
+        Regression guard: the previous implementation called
+        bytes.fromhex(self.approval_data.removeprefix("0x")) — which raises
+        TypeError because approval_data is bytes, not str. Asserting the
+        batch is built with the exact bytes catches that re-introduction.
+        """
+        request_behaviour._balance_tracker = "0xtracker"
+        request_behaviour._approval_data = b"\xab\xcd\xef"
+        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour._approve_balance_tracker = _gen_returning(True)
+
+        result = _drive_generator(request_behaviour._build_token_approval())
+
+        assert result is True
+        assert len(request_behaviour.multisend_batches) == 1
+        batch = request_behaviour.multisend_batches[0]
+        assert batch.to == "0xtoken"
+        assert batch.data == b"\xab\xcd\xef"
+        assert isinstance(batch.data, bytes)
+
+    def test_skips_get_balance_tracker_when_already_set(
+        self, request_behaviour
+    ) -> None:
+        """If _balance_tracker is already populated, _get_balance_tracker is skipped."""
+        request_behaviour._balance_tracker = "0xtracker"
+        request_behaviour._approval_data = b"\x01"
+        request_behaviour.context.params.price_token = "0xtoken"
+        get_called = False
+
+        def get_tracker():
+            nonlocal get_called
+            get_called = True
+            yield
+            return True
+
+        request_behaviour._get_balance_tracker = get_tracker
+        request_behaviour._approve_balance_tracker = _gen_returning(True)
+
+        result = _drive_generator(request_behaviour._build_token_approval())
+
+        assert result is True
+        assert get_called is False
+
+    def test_calls_get_balance_tracker_when_unset(self, request_behaviour) -> None:
+        """If _balance_tracker is unset, _get_balance_tracker runs first."""
+        request_behaviour._balance_tracker = None
+        request_behaviour._approval_data = b"\x01"
+        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour._get_balance_tracker = _gen_returning(True)
+        request_behaviour._approve_balance_tracker = _gen_returning(True)
+
+        result = _drive_generator(request_behaviour._build_token_approval())
+
+        assert result is True
+        assert len(request_behaviour.multisend_batches) == 1
+
+    def test_returns_false_and_warns_when_get_balance_tracker_fails(
+        self, request_behaviour
+    ) -> None:
+        """A failure to fetch the balance tracker short-circuits with a warning."""
+        request_behaviour._balance_tracker = None
+        request_behaviour._get_balance_tracker = _gen_returning(False)
+        approve_called = False
+
+        def approve():
+            nonlocal approve_called
+            approve_called = True
+            yield
+            return True
+
+        request_behaviour._approve_balance_tracker = approve
+
+        result = _drive_generator(request_behaviour._build_token_approval())
+
+        assert result is False
+        assert approve_called is False
+        assert request_behaviour.multisend_batches == []
+        request_behaviour.context.logger.warning.assert_called_once_with(
+            "Failed to get balance tracker."
+        )
+
+    def test_returns_false_and_errors_when_approve_fails(
+        self, request_behaviour
+    ) -> None:
+        """A failure to build the approval short-circuits with an error log."""
+        request_behaviour._balance_tracker = "0xtracker"
+        request_behaviour._approve_balance_tracker = _gen_returning(False)
+
+        result = _drive_generator(request_behaviour._build_token_approval())
+
+        assert result is False
+        assert request_behaviour.multisend_batches == []
+        request_behaviour.context.logger.error.assert_called_once_with(
+            "Failed to build approval data."
+        )

--- a/packages/valory/skills/mech_interact_abci/tests/behaviours/test_request.py
+++ b/packages/valory/skills/mech_interact_abci/tests/behaviours/test_request.py
@@ -269,7 +269,7 @@ class TestApproveBalanceTracker:
         request_behaviour.contract_interact = mock_contract_interact
         request_behaviour._balance_tracker = "0xtracker"
         request_behaviour._mech_max_delivery_rate = 1234
-        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour.context.params.price_token = "0xtoken"  # nosec B105
         request_behaviour.context.params.mech_chain_id = 100
         return captured
 
@@ -325,7 +325,7 @@ class TestBuildTokenApproval:
         """
         request_behaviour._balance_tracker = "0xtracker"
         request_behaviour._approval_data = b"\xab\xcd\xef"
-        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour.context.params.price_token = "0xtoken"  # nosec B105
         request_behaviour._approve_balance_tracker = _gen_returning(True)
 
         result = _drive_generator(request_behaviour._build_token_approval())
@@ -343,7 +343,7 @@ class TestBuildTokenApproval:
         """If _balance_tracker is already populated, _get_balance_tracker is skipped."""
         request_behaviour._balance_tracker = "0xtracker"
         request_behaviour._approval_data = b"\x01"
-        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour.context.params.price_token = "0xtoken"  # nosec B105
         get_called = False
 
         def get_tracker():
@@ -364,7 +364,7 @@ class TestBuildTokenApproval:
         """If _balance_tracker is unset, _get_balance_tracker runs first."""
         request_behaviour._balance_tracker = None
         request_behaviour._approval_data = b"\x01"
-        request_behaviour.context.params.price_token = "0xtoken"
+        request_behaviour.context.params.price_token = "0xtoken"  # nosec B105
         request_behaviour._get_balance_tracker = _gen_returning(True)
         request_behaviour._approve_balance_tracker = _gen_returning(True)
 


### PR DESCRIPTION
## Summary

The marketplace-v2 token-payment request path crashed on the very first request:

```python
data=bytes.fromhex(self.approval_data.removeprefix("0x").removeprefix("0X"))
```

`self._approval_data` is `bytes` (returned by `ERC20TokenContract.build_approval_tx` as `bytes.fromhex(data[2:])`, preserved through `DictProtobufStructSerializer`), so calling `.removeprefix("0x")` on it raises `TypeError: a bytes-like object is required, not 'str'`. The bug was masked from mypy by an incorrect `Optional[str]` annotation that has been wrong since the feature shipped.

The path is gated on marketplace-v2 + `using_token` (USDC/OLAS direct ERC20), which is why it didn't surface in native or NVM flows. Both `_approve_balance_tracker` and `_build_token_approval` carried `# pragma: no cover`, so CI never exercised it either.

## Regression history

The original feature shipped correctly:

- `57d078b` (2025-10-10, "feat: approve the balance tracker for spending tokens") — used `data=HexBytes(self.approval_data)`. ✅ Worked: `HexBytes` accepts `bytes`.
- `8b2e5b2` (2026-04-23, "chore(skill): drop hexbytes + web3 from mech_interact_abci") — replaced `HexBytes(self.approval_data)` with `bytes.fromhex(self.approval_data.removeprefix("0x"))`. ❌ **Bug introduced here.** The dep-cleanup refactor trusted the (wrong) `Optional[str]` annotation and rewrote the line as if `approval_data` were a hex string.
- `82d2867` (2026-04-24, "chore(review): address Divya feedback") — added a second `.removeprefix("0X")` for case-insensitivity. Cosmetic; bug already present.

So the broken state has only existed for ~7 days, and only on the marketplace-v2 token-payment path. The lying type annotation is what let the refactor land.

## Changes

- `behaviours/request.py`:
  - Annotation fix: `_approval_data` and the `approval_data` property are now `Optional[bytes]`.
  - Pass `self.approval_data` straight to `MultisendBatch.data` (already accepts `bytes`/`bytearray`); drop the broken `bytes.fromhex(...removeprefix...)` dance.
  - Remove `# pragma: no cover` from `_approve_balance_tracker` and `_build_token_approval`.
- `tests/behaviours/test_request.py`:
  - `TestApproveBalanceTracker` (3 tests) — asserts every kwarg passed to `contract_interact` (callable, `data_key`, `placeholder`, spender, amount, chain_id), failure propagation, and the info log.
  - `TestBuildTokenApproval` (5 tests) — including a regression guard that asserts `MultisendBatch.data == b"\xab\xcd\xef"` and `isinstance(batch.data, bytes)`. If anyone re-introduces the `bytes.fromhex(...removeprefix...)` line, this test fails with `TypeError` before reaching the assertion.

Coverage on `behaviours/request.py` is 99% (one pre-existing miss at `select_mech` line 571, unrelated). The two methods touched here are 100% covered.

## Test plan

- [x] `uv run tomte check-code` — black, isort, flake8, mypy, pylint, darglint all clean.
- [x] `uv run tomte check-security` — safety + bandit clean.
- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests/behaviours/test_request.py` — 47/47 pass.
- [x] `uv run make generators` — package hashes locked.
- [ ] Smoke test on a marketplace-v2 mech configured for `TOKEN_USDC` or `TOKEN_OLAS`: confirm the approval batch builds and the multisend lands on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)