### PR TITLE
fix(purchase_subscription): pass tx-data bytes through unchanged

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeifip7e6al6nwtwbyqol4xm2iqnuycrdefdie7vyxlxeh33ubqeooa",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeie267gridf6z2yxk7cvt5fdy66cocyg5dn3rj7zvnvl3otnk6iw34",
         "contract/valory/subscription_provider/0.1.0": "bafybeibulnegkf7jsz4lrhvsvai65wytjspl6itkhb6dhbl3fwsbpbyh6u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibzmqjyggvnvbuutmk2a7ju7cfdydj3qthenhojcf6olwweuhu6oy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeid3vzknnl72glpy4w24wsb7kur2gwblta4uwpuwmy2bgl75fenafm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -27,10 +27,10 @@
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
         "contract/valory/multisend/0.1.0": "bafybeic4534fd4axozjmykpstgjynxzpkpfvnvyjt7hz32ajfe3fmwhn7m",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeihpzvi2rxvdzujrqivnynsoqezklval6j3qeoxaitquktvwscqgra",
-        "contract/valory/agent_registry/0.1.0": "bafybeihix534wbt7nq5qaneww5j4b74ce6rf33xgbochpc6xcogzhmnv7q",
+        "contract/valory/agent_registry/0.1.0": "bafybeidjbneskgge442hfmb2mcyap6v723qz2imhlyptt4ofwqbyttmufu",
         "contract/valory/service_registry/0.1.0": "bafybeifuexvcj6w3j2lludzxi3rgu2nn2b3toyifxiy46hv726o2bxivjm",
         "contract/valory/gnosis_safe/0.1.0": "bafybeihljnuo6jiyqfvow4vgxy5ih4eha2pjtguh7o6pabe24lbd6mwjaa",
-        "contract/valory/erc20/0.1.0": "bafybeigjxwhx4li5hmyv3hrtatwq65gl4wihqysaq5pqlpmw5o4lymfv6y",
+        "contract/valory/erc20/0.1.0": "bafybeicn3fsqwourxfh5r7izebhtcqz6idqaxbmp4osqnabcqck3xae4xy",
         "contract/valory/agent_mech/0.1.0": "bafybeieehgxkc3mosiramapon4u7qkhihxa52actku4wlykypovgcjsjde",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeifip7e6al6nwtwbyqol4xm2iqnuycrdefdie7vyxlxeh33ubqeooa",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeie267gridf6z2yxk7cvt5fdy66cocyg5dn3rj7zvnvl3otnk6iw34",
         "contract/valory/subscription_provider/0.1.0": "bafybeibulnegkf7jsz4lrhvsvai65wytjspl6itkhb6dhbl3fwsbpbyh6u",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeid3vzknnl72glpy4w24wsb7kur2gwblta4uwpuwmy2bgl75fenafm"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibnm2g7zludeukslis3tqjmyya6zx5pe5bk7til2jticnbsbo7wsq"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -27,10 +27,10 @@
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
         "contract/valory/multisend/0.1.0": "bafybeic4534fd4axozjmykpstgjynxzpkpfvnvyjt7hz32ajfe3fmwhn7m",
         "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeihpzvi2rxvdzujrqivnynsoqezklval6j3qeoxaitquktvwscqgra",
-        "contract/valory/agent_registry/0.1.0": "bafybeidjbneskgge442hfmb2mcyap6v723qz2imhlyptt4ofwqbyttmufu",
+        "contract/valory/agent_registry/0.1.0": "bafybeihix534wbt7nq5qaneww5j4b74ce6rf33xgbochpc6xcogzhmnv7q",
         "contract/valory/service_registry/0.1.0": "bafybeifuexvcj6w3j2lludzxi3rgu2nn2b3toyifxiy46hv726o2bxivjm",
         "contract/valory/gnosis_safe/0.1.0": "bafybeihljnuo6jiyqfvow4vgxy5ih4eha2pjtguh7o6pabe24lbd6mwjaa",
-        "contract/valory/erc20/0.1.0": "bafybeicn3fsqwourxfh5r7izebhtcqz6idqaxbmp4osqnabcqck3xae4xy",
+        "contract/valory/erc20/0.1.0": "bafybeigjxwhx4li5hmyv3hrtatwq65gl4wihqysaq5pqlpmw5o4lymfv6y",
         "contract/valory/agent_mech/0.1.0": "bafybeieehgxkc3mosiramapon4u7qkhihxa52actku4wlykypovgcjsjde",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",

--- a/packages/valory/skills/mech_interact_abci/behaviours/purchase_subcription.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/purchase_subcription.py
@@ -117,9 +117,9 @@ class MechPurchaseSubscriptionBehaviour(MechInteractBaseBehaviour):
         self._transfer_id: Optional[bytes] = None
         self._escrow_hash: Optional[bytes] = None
         self._escrow_id: Optional[bytes] = None
-        self._agreement_tx_data: Optional[str] = None
-        self._subscription_token_approval_tx_data: Optional[str] = None
-        self._fulfill_tx_data: Optional[str] = None
+        self._agreement_tx_data: Optional[bytes] = None
+        self._subscription_token_approval_tx_data: Optional[bytes] = None
+        self._fulfill_tx_data: Optional[bytes] = None
 
     @property
     def nvm_config(self) -> NVMConfig:  # pragma: no cover
@@ -284,9 +284,7 @@ class MechPurchaseSubscriptionBehaviour(MechInteractBaseBehaviour):
                 "Accessing `_agreement_tx_data` before they have been built."
             )
             return None
-        return bytes.fromhex(
-            self._agreement_tx_data.removeprefix("0x").removeprefix("0X")
-        )
+        return self._agreement_tx_data
 
     @property
     def subscription_token_approval_tx_data(self) -> Optional[bytes]:
@@ -296,11 +294,7 @@ class MechPurchaseSubscriptionBehaviour(MechInteractBaseBehaviour):
                 "Accessing `_subscription_token_approval_tx_data` before they have been built."
             )
             return None
-        return bytes.fromhex(
-            self._subscription_token_approval_tx_data.removeprefix("0x").removeprefix(
-                "0X"
-            )
-        )
+        return self._subscription_token_approval_tx_data
 
     @property
     def fulfill_tx_data(self) -> Optional[bytes]:
@@ -310,9 +304,7 @@ class MechPurchaseSubscriptionBehaviour(MechInteractBaseBehaviour):
                 "Accessing `_fulfill_tx_data` before they have been built."
             )
             return None
-        return bytes.fromhex(
-            self._fulfill_tx_data.removeprefix("0x").removeprefix("0X")
-        )
+        return self._fulfill_tx_data
 
     @property
     def fulfill_for_delegate_params(

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeiedil4txl33ot7lfqf2j3w25lzickfruquh37s2bzbdby4eewysty
 - valory/mech_mm:0.1.0:bafybeiew5cp7zlzsk34btkytgqdxl3bjile6chlnxsi7s3t242aelrmycu
 - valory/multisend:0.1.0:bafybeic4534fd4axozjmykpstgjynxzpkpfvnvyjt7hz32ajfe3fmwhn7m
-- valory/erc20:0.1.0:bafybeicn3fsqwourxfh5r7izebhtcqz6idqaxbmp4osqnabcqck3xae4xy
+- valory/erc20:0.1.0:bafybeigjxwhx4li5hmyv3hrtatwq65gl4wihqysaq5pqlpmw5o4lymfv6y
 - valory/agent_mech:0.1.0:bafybeieehgxkc3mosiramapon4u7qkhihxa52actku4wlykypovgcjsjde
 - valory/mech_marketplace_legacy:0.1.0:bafybeiagaql3kt3mjt6le4rw7mwi5twawojr7anm26bvommb4i7ll7u2zq
-- valory/agent_registry:0.1.0:bafybeidjbneskgge442hfmb2mcyap6v723qz2imhlyptt4ofwqbyttmufu
+- valory/agent_registry:0.1.0:bafybeihix534wbt7nq5qaneww5j4b74ce6rf33xgbochpc6xcogzhmnv7q
 - valory/ierc1155:0.1.0:bafybeie54mrzlup5q6ovgcae35f2aecb6l6ekwa6dhrkgrmotojkyqd2ji
 - valory/nvm_balance_tracker_token:0.1.0:bafybeie5lciwhzieuzbpgejx37dtrmj4q6r2x6omv2ekiwrfeyhjzyje7e
 - valory/nvm_balance_tracker_native:0.1.0:bafybeiepuod5ffnf5wrfqpshkzdbl76ccqdtedqhf7wc7dx47gkmt7jrhu

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -14,7 +14,7 @@ fingerprint:
   behaviours/base.py: bafybeieigufombqm2hmzbmhbkzxt6apnqns5y7gz627v74sffg6a2jyovi
   behaviours/mech_info.py: bafybeidleagib3fzbtehwotw54isgtc3kdwuvhxq3e3icccvky7cixzywy
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
-  behaviours/purchase_subcription.py: bafybeigbd652kkbd4q42za3mn26ixnb5te6yu3ms5dr54w5h4oqov4pxya
+  behaviours/purchase_subcription.py: bafybeidgmrlaeqaedl6gmh23z2ng6u47lyykhphivlowsainidtdlzqowm
   behaviours/request.py: bafybeifaulssfqbxex7mnjzpdmggwdw3zk7fowgxn4e4b2gcnpq6s4ovcq
   behaviours/response.py: bafybeidzrk4ghsbley3mizsevexmr3ghvu4qih4whaysskjzws5i35junu
   behaviours/round_behaviour.py: bafybeige7ajovc2u3vjb2elodqi47urfb5nms4felsx4b7jb3zaorimjv4
@@ -41,7 +41,7 @@ fingerprint:
   tests/behaviours/conftest.py: bafybeie7z3k5zdrjx2f6acltma36ww7oabtisplfmfrxfxmw4wyoghqaxa
   tests/behaviours/test_base.py: bafybeicg4rgbj6touygc5v64jdl6h4vligldqb4rfhmnunksnbmytstp5u
   tests/behaviours/test_mech_version.py: bafybeicuapex7burjwnxrq2lhoihtgyp6i64mkcdigtjihutwvjrbt5w3q
-  tests/behaviours/test_purchase_subscription.py: bafybeiapngvvm26wtzc4iszts3wkj6duvchucyuylvrvsealvbpnpiw36m
+  tests/behaviours/test_purchase_subscription.py: bafybeicwmxjls6ffdbsgo5yt47qg6tr3p7dl6lw5qjku5nx24xaniqdtuu
   tests/behaviours/test_request.py: bafybeicwskajjowt4lxttaxv6ciskdpvzzfbuzzgu45htfyf3msuoygvcm
   tests/behaviours/test_response.py: bafybeigxuosfyhqfucq2gferbo4xejfs6a4v3skoes342lfnr7r5xmhowq
   tests/states/__init__.py: bafybeieo3txynlsaxtuqxvvhjyjn2hft3ztsnr5v6byoccqg2allecx2vm
@@ -66,10 +66,10 @@ contracts:
 - valory/mech:0.1.0:bafybeiedil4txl33ot7lfqf2j3w25lzickfruquh37s2bzbdby4eewysty
 - valory/mech_mm:0.1.0:bafybeiew5cp7zlzsk34btkytgqdxl3bjile6chlnxsi7s3t242aelrmycu
 - valory/multisend:0.1.0:bafybeic4534fd4axozjmykpstgjynxzpkpfvnvyjt7hz32ajfe3fmwhn7m
-- valory/erc20:0.1.0:bafybeigjxwhx4li5hmyv3hrtatwq65gl4wihqysaq5pqlpmw5o4lymfv6y
+- valory/erc20:0.1.0:bafybeicn3fsqwourxfh5r7izebhtcqz6idqaxbmp4osqnabcqck3xae4xy
 - valory/agent_mech:0.1.0:bafybeieehgxkc3mosiramapon4u7qkhihxa52actku4wlykypovgcjsjde
 - valory/mech_marketplace_legacy:0.1.0:bafybeiagaql3kt3mjt6le4rw7mwi5twawojr7anm26bvommb4i7ll7u2zq
-- valory/agent_registry:0.1.0:bafybeihix534wbt7nq5qaneww5j4b74ce6rf33xgbochpc6xcogzhmnv7q
+- valory/agent_registry:0.1.0:bafybeidjbneskgge442hfmb2mcyap6v723qz2imhlyptt4ofwqbyttmufu
 - valory/ierc1155:0.1.0:bafybeie54mrzlup5q6ovgcae35f2aecb6l6ekwa6dhrkgrmotojkyqd2ji
 - valory/nvm_balance_tracker_token:0.1.0:bafybeie5lciwhzieuzbpgejx37dtrmj4q6r2x6omv2ekiwrfeyhjzyje7e
 - valory/nvm_balance_tracker_native:0.1.0:bafybeiepuod5ffnf5wrfqpshkzdbl76ccqdtedqhf7wc7dx47gkmt7jrhu

--- a/packages/valory/skills/mech_interact_abci/tests/behaviours/test_purchase_subscription.py
+++ b/packages/valory/skills/mech_interact_abci/tests/behaviours/test_purchase_subscription.py
@@ -177,27 +177,16 @@ class TestTxDataProperties:
         ],
     )
     def test_returns_bytes_when_set(self, purchase_behaviour, attr, prop) -> None:
-        """Test returns bytes when backing field is set."""
-        setattr(purchase_behaviour, attr, "0xabcd")
-        result = getattr(purchase_behaviour, prop)
-        assert result == b"\xab\xcd"
+        """Test the property passes the backing bytes through unchanged.
 
-    @pytest.mark.parametrize(
-        "attr,prop",
-        [
-            ("_agreement_tx_data", "agreement_tx_data"),
-            (
-                "_subscription_token_approval_tx_data",
-                "subscription_token_approval_tx_data",
-            ),
-            ("_fulfill_tx_data", "fulfill_tx_data"),
-        ],
-    )
-    def test_accepts_uppercase_hex_prefix(self, purchase_behaviour, attr, prop) -> None:
-        """Test `0X` prefix is stripped alongside `0x` (case-insensitive)."""
-        setattr(purchase_behaviour, attr, "0XABCD")
+        The backing field is populated by `contract_interact` from contract
+        methods that return raw `bytes` (`bytes.fromhex(encoded_data[2:])`),
+        so the property must surface those bytes as-is.
+        """
+        setattr(purchase_behaviour, attr, b"\xab\xcd")
         result = getattr(purchase_behaviour, prop)
         assert result == b"\xab\xcd"
+        assert isinstance(result, bytes)
 
 
 class TestGenerateAgreementIdSeed:


### PR DESCRIPTION
## Summary

Three more occurrences of the same bytes-vs-str regression fixed in #76. All three sit in `behaviours/purchase_subcription.py` and follow the identical shape: an attribute is annotated `Optional[str]`, populated with `bytes` by `contract_interact`, then decoded as a hex string via `bytes.fromhex(self._foo.removeprefix("0x").removeprefix("0X"))`. The first real call raises `TypeError: a bytes-like object is required, not 'str'`.

| Attribute | Setter | Contract | Path that crashes |
| --- | --- | --- | --- |
| `_subscription_token_approval_tx_data` | `_build_subscription_token_approval_tx_data` (line 613) | `ERC20TokenContract.build_approval_tx` (`erc20/contract.py:184-197`) | Base-chain USDC subscription approval |
| `_agreement_tx_data` | `_build_create_agreement_tx_data` (line 576) | `NFTSalesTemplate.build_create_agreement_tx` (`nft_sales/contract.py:39-74`) | NVM subscription create-agreement |
| `_fulfill_tx_data` | `_build_create_fulfill_tx_data` (line 644) | `SubscriptionProvider.build_create_fulfill_tx` (`subscription_provider/contract.py:36-53`) | NVM subscription fulfill |

All three contracts return `{"data": bytes.fromhex(encoded_data[2:])}` — raw bytes — and `contract_interact` sets the placeholder via `setattr(self, placeholder, data)` with no type coercion, so the runtime value has always been `bytes` despite the annotation.

## Changes

- `behaviours/purchase_subcription.py`:
  - Flip `__init__` annotations from `Optional[str]` to `Optional[bytes]` for the three fields.
  - Drop the `bytes.fromhex(self._foo.removeprefix("0x").removeprefix("0X"))` ceremony in each property and return the bytes directly. `MultisendBatch.data` accepts `bytes`/`bytearray` and validates via `__post_init__`, so a regression to a string fails loudly at construction.
- `tests/behaviours/test_purchase_subscription.py`:
  - Rewrite `TestTxDataProperties::test_returns_bytes_when_set` to set `b"\xab\xcd"` (matching what `contract_interact` actually writes) and assert the bytes pass through unchanged plus `isinstance(result, bytes)`. The previous version set the string `"0xabcd"` and asserted `b"\xab\xcd"`, which froze the bug instead of detecting it.
  - Drop `test_accepts_uppercase_hex_prefix` — no prefix-stripping behaviour left to test.

## Test plan

- [x] `uv run tomte check-code` — black, isort, flake8, mypy, pylint, darglint all clean.
- [x] `uv run tomte check-security` — safety + bandit clean.
- [x] `uv run pytest packages/valory/skills/mech_interact_abci/tests/behaviours/test_purchase_subscription.py` — 36/36 pass.
- [x] `uv run make generators` — package hashes locked.
- [ ] Smoke test: trigger a marketplace-v2 NVM subscription purchase on Base; confirm the create-agreement, USDC-approval, and fulfill multisend batches build and land on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)