### PR TITLE
chore(mech_interact_abci): drop irrelevant_tools, valid_tools is the single allowlist

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,11 @@ Below, we describe the additional manual steps required to upgrade between diffe
 ## Unreleased (built with `open-aea@2.2.3` and `open-autonomy@0.21.20`)
 
 #### Breaking Changes
+- The `irrelevant_tools` blocklist has been removed. Any overlay that still
+  sets `irrelevant_tools` will be silently ignored. Curate `valid_tools`
+  as the single tool allowlist instead: anything previously in
+  `irrelevant_tools` must be omitted from `valid_tools`. Per-mech
+  `relevant_tools` is now just `metadata_tools & valid_tools`.
 - The `ignored_mechs` blocklist has been removed. Any overlay
   (`aea-config.yaml`, `service.yaml`) that still sets `ignored_mechs` will be
   silently ignored. Replace it with the new `valid_mechs` allowlist.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,6 +101,8 @@ Below, we describe the additional manual steps required to upgrade between diffe
     - `mechs_info`: All the mechs' information.
     - `relevant_mechs_info`: The mechs' information that are relevant to the user, 
       i.e., include tools which are not in the `irrelevant_tools` set.
+      (Note: `irrelevant_tools` was removed in the Unreleased section above;
+      from that version on, the filter is `metadata_tools & valid_tools`.)
     - `mech_tools`: The set of all the mechs' tools.
     - `priority_mech`: The dynamically picked priority mech.
     - `priority_mech_address`: The address of the dynamically picked priority mech.
@@ -118,6 +120,7 @@ Below, we describe the additional manual steps required to upgrade between diffe
     - `FinishedMechInformationRound`: Triggered if the mech information gathering was successfully performed.
     - `FailedMechInformationRound`: Triggered if the mech information gathering failed.
 - The `irrelevant_tools` are now defined in this skill. This is a list of tools which should never be picked.
+  (Note: `irrelevant_tools` was removed in the Unreleased section above; see Breaking Changes there.)
 - New models have been introduced in `skill.yaml` and `models.py` and should be defined in the composed skills too:
   - `MechToolsSpecs`
   - `MechsSubgraph`

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeiepuolertcivkglrgn32yfd2ykmozuycemp73fnqekvnlhc6o3rci",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeih2gyvouuhhbiwil2c5xhqq2aokdkwrkrpftte5tyiwyuqn27gnfe",
         "contract/valory/subscription_provider/0.1.0": "bafybeid5hvuugwsugq5verujlgfjw2lzchhnucjjnxhjzm4tpdbqht7etm",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibcr5ifxkkeb4q3jbyxhri2yrydiunh5csifermqdcboa2ydybu6m"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -136,9 +136,7 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                 continue
 
             metadata_tools = {str(t).lower() for t in res}
-            allowed_tools = (
-                metadata_tools - self.params.irrelevant_tools
-            ) & self.params.valid_tools
+            allowed_tools = metadata_tools & self.params.valid_tools
             for mech in mechs:
                 mech.relevant_tools |= allowed_tools
             self.mech_tools_api.reset_retries()

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -296,7 +296,6 @@ class MechParams(BaseParams):
         self.use_acn_for_delivers: bool = self._ensure(
             "use_acn_for_delivers", kwargs, bool
         )
-        self.irrelevant_tools: set = set(self._ensure("irrelevant_tools", kwargs, list))
         self.valid_mechs: FrozenSet[str] = frozenset(
             str(addr).lower() for addr in self._ensure("valid_mechs", kwargs, List[str])
         )

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeiggfcw7zt6glthh47kszk7ymadzgkr27qixswfmsqiezxr5hmekb4
-  behaviours/mech_info.py: bafybeiemp3dkzxcmzqoqepkzerpsyeppp5mz5lbjor556345skdh2ntd54
+  behaviours/mech_info.py: bafybeibpw5znizkqvtomprybjduwk37nskgsaxj2kmlowhxwmlatnecn3a
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
   behaviours/request.py: bafybeifhy47fhj3m5rfejy7kajr55sthmzqqydavz7vm5ep3x4v6p554nm
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeifklh73m2zkd447f6e3nk6xsv53l5eg4xip3rk6gyi6s6ptuivux4
   graph_tooling/requests.py: bafybeiblfdl22brohgmholbcir3f344as5nk6fwnwuljfc7rovd6dnifea
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeicwl62gboyjzimpckjyw4pfmskhbuzyzjqa4apviv467v4ggh6wbi
+  models.py: bafybeig34mqct7zunxu4acvw5ljgfwkqoc754vgp4ff6p3wmm6yabde7va
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeidwg2xei3fbrhe4qtr6c7ngpnjdpmfi6p2wpnkx5ig76schegiuv4
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeihvo4mw3f3oizodlnysaw5nyup7rd3pm4zt2xkaa7nj6rr62vbjhq
-  tests/test_mech_info_behaviour.py: bafybeifo3hecbha32utwergtsk4yu56koq3cdb3s5je4suayphbb3e3vn4
+  tests/test_mech_info_behaviour.py: bafybeidgrv422kaxt6qnycdjoylpdg5ythtangxpcjzaxg34da44j7cfx4
   tests/test_models.py: bafybeid5izwmvai4a7lnmn4ru3f2c2xjuu45wlkil6b6v6gedxuxsrulia
   tests/test_payloads.py: bafybeibjkrdwkxqw73d7eaxwtqepigi4gutkvqaxqhj3os5nsmjffqkc4y
   tests/test_request_behaviour.py: bafybeiflipc3xfuaaas36bnkbg632d3kzd2qkp4e5vvdyui3y77u7fo7ue
@@ -213,15 +213,6 @@ models:
         mech_marketplace_address: '0x0000000000000000000000000000000000000000'
         priority_mech_address: '0x0000000000000000000000000000000000000000'
         response_timeout: 300
-      irrelevant_tools:
-      - openai-text-davinci-002
-      - openai-text-davinci-003
-      - openai-gpt-3.5-turbo
-      - openai-gpt-4
-      - stabilityai-stable-diffusion-v1-5
-      - stabilityai-stable-diffusion-xl-beta-v2-2-2
-      - stabilityai-stable-diffusion-512-v2-1
-      - stabilityai-stable-diffusion-768-v2-1
       deliveries_lookback_days: 30
       valid_mechs: []
       valid_tools: []

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -97,7 +97,6 @@ def _setup_api(
     """Set up a behaviour with mocked context.params and mech_tools_api."""
     behaviour._context.params = MagicMock()
     behaviour._context.params.ipfs_address = "https://ipfs.io/"
-    behaviour._context.params.irrelevant_tools = set()
     behaviour._context.params.valid_mechs = valid_mechs or frozenset()
     behaviour._context.params.valid_tools = valid_tools or frozenset()
 
@@ -167,14 +166,13 @@ class TestPopulateTools:
         assert called["count"] == 0
 
     def test_populates_tools_from_http_response(self) -> None:
-        """Tools fetched via HTTP and populated on the mech."""
+        """Tools fetched via HTTP intersected with valid_tools allowlist."""
         behaviour = _make_mech_info_behaviour()
         api = _setup_api(
             behaviour,
             valid_tools=frozenset({"tool_a", "tool_b"}),
         )
-        api.process_response.return_value = ["tool_a", "tool_b", "irrelevant_tool"]
-        behaviour._context.params.irrelevant_tools = {"irrelevant_tool"}
+        api.process_response.return_value = ["tool_a", "tool_b", "tool_c"]
 
         mech = _make_mech_info(relevant_tools=set())
         _wire_get_http_response(behaviour, [MagicMock()])
@@ -559,23 +557,6 @@ class TestAllowlistIntersect:
         _drive(behaviour.populate_tools([mech]))
 
         assert mech.relevant_tools == set()
-
-    def test_irrelevant_tools_filtered_before_intersect(self) -> None:
-        """`irrelevant_tools` are removed before the `valid_tools` intersect."""
-        behaviour = _make_mech_info_behaviour()
-        api = _setup_api(
-            behaviour,
-            valid_tools=frozenset({"tool_a", "tool_b", "junk"}),
-        )
-        api.process_response.return_value = ["tool_a", "tool_b", "junk"]
-        behaviour._context.params.irrelevant_tools = {"junk"}
-
-        mech = _make_mech_info(relevant_tools=set())
-        _wire_get_http_response(behaviour, [MagicMock()])
-
-        _drive(behaviour.populate_tools([mech]))
-
-        assert mech.relevant_tools == {"tool_a", "tool_b"}
 
 
 class TestLastFailureReason:


### PR DESCRIPTION
## Summary

Following the PR #79 review thread with @bennyjo: keeping both `irrelevant_tools` (denylist) and `valid_tools` (allowlist) is redundant. Operators can express any denylist intent by simply omitting tools from `valid_tools`. This PR collapses the per-mech filter from `(metadata_tools - irrelevant_tools) & valid_tools` to `metadata_tools & valid_tools`.

## Changes
- `models.py`: drop `self.irrelevant_tools` and its `_ensure("irrelevant_tools", ...)` call from `MechParams.__init__`.
- `behaviours/mech_info.py`: drop the subtraction step in `populate_tools` (see [the previous line at `mech_info.py:140-141`](https://github.com/valory-xyz/mech-interact/blob/v0.31.0/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py#L140-L141) for the old form).
- `skill.yaml`: drop the default `irrelevant_tools` list.
- Tests: drop the dedicated `test_irrelevant_tools_filtered_before_intersect`; simplify `test_populates_tools_from_http_response` to exercise the `valid_tools`-only path.
- `UPGRADING.md`: document the breaking change and the migration path.

## Where the prod denylist lived
The production `IRRELEVANT_TOOLS` env var template lives in operate-app at [`frontend/constants/serviceTemplates/service/trader.ts:124-128`](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L124-L128) (Pearl/Gnosis) and [`:271-276`](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/constants/serviceTemplates/service/trader.ts#L271-L276) (Polystrat/Polygon). Pearl + operate-app need to drop those `IRRELEVANT_TOOLS` templates in a follow-up; trader's seeded `valid_tools` will be curated down to the effective set (`prediction-offline`, `superforcaster`, `factual_research` on Gnosis; `superforcaster` on Polygon) in the companion trader PR.

## Test plan
- [x] Unit tests pass (`uv run pytest packages/valory/skills/mech_interact_abci/`).
- [x] `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e darglint` clean.
- [x] `autonomy packages lock --check` succeeds.
- [x] `autonomy push-all` published the new hash to IPFS.
- [ ] Companion trader PR to land after this merges + `v0.32.0` tag is cut.

New mech_interact_abci hash: \`bafybeihds6vqk3gsevtsdsowz56jdnbbhc6gnswwd25opm6rrj32dhsmou\`.