### PR TITLE
chore(mech_interact_abci): drop valid_tools allowlist; suitability is the consumer's job

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,22 @@ Below, we describe the additional manual steps required to upgrade between diffe
 ## Unreleased (built with `open-aea@2.2.6` and `open-autonomy@0.21.22`)
 
 #### Breaking Changes
+- The `valid_tools` operator allowlist has been removed from
+  `mech_interact_abci`. The skill no longer filters per-mech
+  `relevant_tools` against an operator-curated set; each mech's
+  `relevant_tools` now carries its full IPFS manifest tool list as-is.
+  Tool-suitability decisions are the consumer's responsibility (e.g.
+  `decision_maker_abci` in trader runs an `is_prediction_tool`
+  classifier and may still keep its own `valid_tools` safety net).
+  Any overlay that still sets `valid_tools` on `mech_interact_abci`
+  will fail to load because the param is no longer declared. Move the
+  override into the consumer skill that needs it (e.g.
+  `decision_maker_abci`).
+- The `last_failure_reason` value `no_overlap_with_valid_tools` is
+  renamed to `no_tools_in_manifests` (the only way the trigger
+  condition fires now is when every fetched manifest is empty), and
+  `pinned_mechs_no_valid_tools` is renamed to `pinned_mechs_no_tools`.
+  Consumers that switch on these strings must update accordingly.
 - The `irrelevant_tools` blocklist has been removed. Any overlay that still
   sets `irrelevant_tools` will be silently ignored. Curate `valid_tools`
   as the single tool allowlist instead: anything previously in

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,15 +17,19 @@ Below, we describe the additional manual steps required to upgrade between diffe
   override into the consumer skill that needs it (e.g.
   `decision_maker_abci`).
 - The `last_failure_reason` value `no_overlap_with_valid_tools` is
-  renamed to `no_tools_in_manifests` (the only way the trigger
-  condition fires now is when every fetched manifest is empty), and
-  `pinned_mechs_no_valid_tools` is renamed to `pinned_mechs_no_tools`.
-  Consumers that switch on these strings must update accordingly.
-- The `irrelevant_tools` blocklist has been removed. Any overlay that still
-  sets `irrelevant_tools` will be silently ignored. Curate `valid_tools`
-  as the single tool allowlist instead: anything previously in
-  `irrelevant_tools` must be omitted from `valid_tools`. Per-mech
-  `relevant_tools` is now just `metadata_tools & valid_tools`.
+  renamed to `no_usable_tools_in_mechs`, and
+  `pinned_mechs_no_valid_tools` is renamed to
+  `pinned_mechs_no_usable_tools`. Both reasons now cover the broader
+  trigger: a mech ends up with empty `relevant_tools` when its
+  manifest is empty, permanently failing, or retries-exhausted. The
+  rename reflects this — consumers that switch on the old strings
+  must update accordingly.
+- The `irrelevant_tools` blocklist has been removed. Any overlay that
+  still sets `irrelevant_tools` will be silently ignored. With this
+  release's removal of `valid_tools` too, mech_interact_abci no longer
+  filters tools at the transport layer at all — each mech's
+  `relevant_tools` carries its full IPFS manifest tool list, and any
+  tool-suitability filtering is the consumer's responsibility.
 - The `ignored_mechs` blocklist has been removed. Any overlay
   (`aea-config.yaml`, `service.yaml`) that still sets `ignored_mechs` will be
   silently ignored. Replace it with the new `valid_mechs` allowlist.
@@ -52,11 +56,6 @@ Below, we describe the additional manual steps required to upgrade between diffe
   addresses (case-insensitive, lowercased on load). Empty default. With
   marketplace v2 dynamic selection enabled and `valid_mechs` empty, the
   skill logs a startup warning and short-circuits the subgraph fetch.
-- New `valid_tools: List[str]` skill param: a flat allowlist of tool
-  names. Each mech's IPFS manifest is intersected with this set; only
-  tools that appear in both are surfaced as `relevant_tools`. Both
-  sides of the intersect are lowercased, so a `Prediction-Online` in
-  `service.yaml` will match a `prediction-online` manifest entry.
 - New `SynchronizedData.selected_mechs` property: a list of lowercase mech
   addresses that further restricts `relevant_mechs_info` AND `mech_tools`
   when non-empty (so a consumer can't pick a tool no pinned mech serves).
@@ -64,20 +63,21 @@ Below, we describe the additional manual steps required to upgrade between diffe
   mechanism.
 - New `SharedState.last_failure_reason` diagnostic string set on each
   failure path: `subgraph_unavailable`, `allowlist_not_configured`,
-  `valid_mech_list_empty`, `no_overlap_with_valid_tools`,
-  `pinned_mechs_offline` (written by `MechInformationBehaviour` when a
-  non-empty `selected_mechs` has no overlap with this round's
-  `mech_info`), `pinned_mechs_no_valid_tools` (written when pinned mechs
-  are visible but their IPFS manifests don't intersect `valid_tools`),
+  `valid_mech_list_empty`, `no_usable_tools_in_mechs` (no mech in
+  this round has usable tools — manifest empty or unreachable),
+  `pinned_mechs_offline` (written by `MechInformationBehaviour` when
+  a non-empty `selected_mechs` has no overlap with this round's
+  `mech_info`), `pinned_mechs_no_usable_tools` (written when pinned
+  mechs are visible but have empty `relevant_tools` for any reason),
   `no_overlap_with_selected_mechs` (written by `MechRequestBehaviour`
   when a non-empty `selected_mechs` pin yields no candidate for the
-  chosen tool), `no_overlap_with_selected_tool` (written when no pin is
-  set but no allowed mech serves the chosen tool),
-  `static_priority_not_in_valid_mechs` (written when the static priority
-  is rejected by the allowlist), and `no_non_penalized_valid_mech`
-  (written when every ranked candidate is under active penalty).
-  Consumed by the trader-side ChatUI handler to surface why a round
-  produced no candidate.
+  chosen tool), `no_overlap_with_selected_tool` (written when no pin
+  is set but no allowed mech serves the chosen tool),
+  `static_priority_not_in_valid_mechs` (written when the static
+  priority is rejected by the allowlist), and
+  `no_non_penalized_valid_mech` (written when every ranked candidate
+  is under active penalty). Consumed by the trader-side ChatUI
+  handler to surface why a round produced no candidate.
 
 ## `v0.22.2` to `v0.22.3` (built with `open-aea@1.65.0` and `open-autonomy@0.19.11`)
 
@@ -118,7 +118,10 @@ Below, we describe the additional manual steps required to upgrade between diffe
     - `relevant_mechs_info`: The mechs' information that are relevant to the user, 
       i.e., include tools which are not in the `irrelevant_tools` set.
       (Note: `irrelevant_tools` was removed in the Unreleased section above;
-      from that version on, the filter is `metadata_tools & valid_tools`.)
+      `valid_tools` was also removed in the same Unreleased section.
+      From that version on, `relevant_tools` carries the full IPFS manifest
+      tool list as-is; tool-suitability filtering is the consumer's
+      responsibility.)
     - `mech_tools`: The set of all the mechs' tools.
     - `priority_mech`: The dynamically picked priority mech.
     - `priority_mech_address`: The address of the dynamically picked priority mech.

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeidkzig2lh4fddifucronf4nyurgvhzaqkkni6i6kn6pj5a5jwuil4",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicbhremevdxsczfen26uv4y2w6a4vzusqq76avopaqihpdzhnrid4",
         "contract/valory/subscription_provider/0.1.0": "bafybeievfd7i5yuut2blymf5nra24zd4xbaykcldvbilh3esln6qdu3gru",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeieceb3pw6curi236q7phfmiuwautcw7piwu6u42mx5ms2athia73y"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeidrgcavhpsrkzj2pvpybu56aj3sohuzuvdaidj5wr2uf35edchhxi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeidkzig2lh4fddifucronf4nyurgvhzaqkkni6i6kn6pj5a5jwuil4",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeicbhremevdxsczfen26uv4y2w6a4vzusqq76avopaqihpdzhnrid4",
         "contract/valory/subscription_provider/0.1.0": "bafybeievfd7i5yuut2blymf5nra24zd4xbaykcldvbilh3esln6qdu3gru",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiexvtbft2iupqojaeodfr6cdn3kmhzbrqa4exeb7vhjs2m7j43hfm"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeieceb3pw6curi236q7phfmiuwautcw7piwu6u42mx5ms2athia73y"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -136,9 +136,8 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                 continue
 
             metadata_tools = {str(t).lower() for t in res}
-            allowed_tools = metadata_tools & self.params.valid_tools
             for mech in mechs:
-                mech.relevant_tools |= allowed_tools
+                mech.relevant_tools |= metadata_tools
             self.mech_tools_api.reset_retries()
 
         return True
@@ -176,7 +175,7 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
             self.context.logger.warning(
                 "No mechs have usable tools after fetch; emitting NONE to retry."
             )
-            self.shared_state.last_failure_reason = "no_overlap_with_valid_tools"
+            self.shared_state.last_failure_reason = "no_tools_in_manifests"
             return None
 
         pinned = self.synchronized_data.selected_mechs
@@ -196,10 +195,10 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
                 for mech in mech_info
             ):
                 self.context.logger.warning(
-                    f"Pinned mechs {sorted(visible_pinned)} are visible but expose "
-                    f"no tools in `valid_tools`."
+                    f"Pinned mechs {sorted(visible_pinned)} are visible but "
+                    f"expose no tools in their manifest."
                 )
-                self.shared_state.last_failure_reason = "pinned_mechs_no_valid_tools"
+                self.shared_state.last_failure_reason = "pinned_mechs_no_tools"
                 return None
 
         # truncate the information, otherwise logs get too big

--- a/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/mech_info.py
@@ -173,9 +173,10 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
 
         if not any(mech.relevant_tools for mech in mech_info):
             self.context.logger.warning(
-                "No mechs have usable tools after fetch; emitting NONE to retry."
+                "No mechs have usable tools after fetch (manifest empty or "
+                "unreachable); emitting NONE to retry."
             )
-            self.shared_state.last_failure_reason = "no_tools_in_manifests"
+            self.shared_state.last_failure_reason = "no_usable_tools_in_mechs"
             return None
 
         pinned = self.synchronized_data.selected_mechs
@@ -196,9 +197,9 @@ class MechInformationBehaviour(QueryingBehaviour, MechInteractBaseBehaviour):
             ):
                 self.context.logger.warning(
                     f"Pinned mechs {sorted(visible_pinned)} are visible but "
-                    f"expose no tools in their manifest."
+                    f"have no usable tools (manifest empty or unreachable)."
                 )
-                self.shared_state.last_failure_reason = "pinned_mechs_no_tools"
+                self.shared_state.last_failure_reason = "pinned_mechs_no_usable_tools"
                 return None
 
         # truncate the information, otherwise logs get too big

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -299,9 +299,6 @@ class MechParams(BaseParams):
         self.valid_mechs: FrozenSet[str] = frozenset(
             str(addr).lower() for addr in self._ensure("valid_mechs", kwargs, List[str])
         )
-        self.valid_tools: FrozenSet[str] = frozenset(
-            str(tool).lower() for tool in self._ensure("valid_tools", kwargs, List[str])
-        )
         self.penalize_mech_time_window: int = self._ensure(
             "penalize_mech_time_window", kwargs, int
         )
@@ -373,21 +370,14 @@ class MechParams(BaseParams):
                         "priority_mech_address is required "
                         "when use_mech_marketplace is True and use_dynamic_mech_selection is False"
                     )
-                if self.mech_marketplace_config.use_dynamic_mech_selection and (
-                    not self.valid_mechs or not self.valid_tools
+                if (
+                    self.mech_marketplace_config.use_dynamic_mech_selection
+                    and not self.valid_mechs
                 ):
-                    missing = ", ".join(
-                        name
-                        for name, populated in (
-                            ("valid_mechs", self.valid_mechs),
-                            ("valid_tools", self.valid_tools),
-                        )
-                        if not populated
-                    )
                     self.context.logger.warning(
-                        f"{missing} is empty while marketplace v2 dynamic selection "
-                        "is enabled. No mech requests will succeed until the "
-                        "allowlist is configured."
+                        "valid_mechs is empty while marketplace v2 dynamic "
+                        "selection is enabled. No mech requests will succeed "
+                        "until the allowlist is configured."
                     )
 
             # Validate sleep time

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeiggfcw7zt6glthh47kszk7ymadzgkr27qixswfmsqiezxr5hmekb4
-  behaviours/mech_info.py: bafybeibpw5znizkqvtomprybjduwk37nskgsaxj2kmlowhxwmlatnecn3a
+  behaviours/mech_info.py: bafybeibowiucbgwrvjsi6ncpzss35qimfh4thkkatk73p2d3knc2gal2em
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
   behaviours/request.py: bafybeifhy47fhj3m5rfejy7kajr55sthmzqqydavz7vm5ep3x4v6p554nm
@@ -25,7 +25,7 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeifklh73m2zkd447f6e3nk6xsv53l5eg4xip3rk6gyi6s6ptuivux4
   graph_tooling/requests.py: bafybeiblfdl22brohgmholbcir3f344as5nk6fwnwuljfc7rovd6dnifea
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeig34mqct7zunxu4acvw5ljgfwkqoc754vgp4ff6p3wmm6yabde7va
+  models.py: bafybeibtfcfdpeaykjgaxwc7fzke4n5yotwdxj2zr2qkqyoiowhrqcogpq
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeidwg2xei3fbrhe4qtr6c7ngpnjdpmfi6p2wpnkx5ig76schegiuv4
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeihvo4mw3f3oizodlnysaw5nyup7rd3pm4zt2xkaa7nj6rr62vbjhq
-  tests/test_mech_info_behaviour.py: bafybeidgrv422kaxt6qnycdjoylpdg5ythtangxpcjzaxg34da44j7cfx4
+  tests/test_mech_info_behaviour.py: bafybeia64wylvqa7upbjknyc6t7uoqrbfgozmr4uthcf6eyr6rb63airxq
   tests/test_models.py: bafybeid5izwmvai4a7lnmn4ru3f2c2xjuu45wlkil6b6v6gedxuxsrulia
   tests/test_payloads.py: bafybeibjkrdwkxqw73d7eaxwtqepigi4gutkvqaxqhj3os5nsmjffqkc4y
   tests/test_request_behaviour.py: bafybeiflipc3xfuaaas36bnkbg632d3kzd2qkp4e5vvdyui3y77u7fo7ue
@@ -215,7 +215,6 @@ models:
         response_timeout: 300
       deliveries_lookback_days: 30
       valid_mechs: []
-      valid_tools: []
       penalize_mech_time_window: 1800
     class_name: Params
   mech_tools:

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -12,7 +12,7 @@ fingerprint:
   __init__.py: bafybeic6zmplvwsgp5gh2rse2ushtaqnodvmb4kxooace5ghabz4exqbt4
   behaviours/__init__.py: bafybeifgcheyski75lgbvssqy6czxq55gnqpjddexhprpsazeczqwkl46q
   behaviours/base.py: bafybeiggfcw7zt6glthh47kszk7ymadzgkr27qixswfmsqiezxr5hmekb4
-  behaviours/mech_info.py: bafybeibowiucbgwrvjsi6ncpzss35qimfh4thkkatk73p2d3knc2gal2em
+  behaviours/mech_info.py: bafybeibwwabrnhgafubf5qrldiyqgjtp6byctlaaczxlvgjvndihjtwjue
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
   behaviours/request.py: bafybeifhy47fhj3m5rfejy7kajr55sthmzqqydavz7vm5ep3x4v6p554nm
@@ -51,7 +51,7 @@ fingerprint:
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeihvo4mw3f3oizodlnysaw5nyup7rd3pm4zt2xkaa7nj6rr62vbjhq
-  tests/test_mech_info_behaviour.py: bafybeia64wylvqa7upbjknyc6t7uoqrbfgozmr4uthcf6eyr6rb63airxq
+  tests/test_mech_info_behaviour.py: bafybeiakoslt7wd6wqlchlumyutng6ayez3f3mafjmahu3kv7xddiqi6si
   tests/test_models.py: bafybeid5izwmvai4a7lnmn4ru3f2c2xjuu45wlkil6b6v6gedxuxsrulia
   tests/test_payloads.py: bafybeibjkrdwkxqw73d7eaxwtqepigi4gutkvqaxqhj3os5nsmjffqkc4y
   tests/test_request_behaviour.py: bafybeiflipc3xfuaaas36bnkbg632d3kzd2qkp4e5vvdyui3y77u7fo7ue

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -19,7 +19,7 @@
 
 """Tests for the mech_info behaviour module."""
 
-from typing import Any, FrozenSet, Generator, List, Optional, Set
+from typing import Any, Generator, List, Optional, Set
 from unittest.mock import MagicMock, patch
 
 from packages.valory.skills.mech_interact_abci.behaviours.mech_info import (
@@ -90,13 +90,16 @@ def _wire_get_http_response(
 
 def _setup_api(
     behaviour: MechInformationBehaviour,
-    valid_mechs: Optional[FrozenSet[str]] = None,
     **overrides: Any,
 ) -> MagicMock:
-    """Set up a behaviour with mocked context.params and mech_tools_api."""
+    """Set up a behaviour with mocked context.params and mech_tools_api.
+
+    Tests that need a non-empty `valid_mechs` set it directly on
+    `behaviour._context.params.valid_mechs` after calling this helper.
+    """
     behaviour._context.params = MagicMock()
     behaviour._context.params.ipfs_address = "https://ipfs.io/"
-    behaviour._context.params.valid_mechs = valid_mechs or frozenset()
+    behaviour._context.params.valid_mechs = frozenset()
 
     api = MagicMock()
     api.__dict__["_frozen"] = True
@@ -567,8 +570,8 @@ class TestLastFailureReason:
 
         assert behaviour._context.state.last_failure_reason == "valid_mech_list_empty"
 
-    def test_writes_no_tools_in_manifests_when_all_manifests_empty(self) -> None:
-        """All manifests returning an empty tools list writes `no_tools_in_manifests`."""
+    def test_writes_no_usable_tools_in_mechs_when_all_manifests_empty(self) -> None:
+        """All manifests returning an empty tools list writes `no_usable_tools_in_mechs`."""
         behaviour = _make_mech_info_behaviour()
         api = _setup_api(behaviour)
         api.process_response.return_value = []
@@ -585,7 +588,9 @@ class TestLastFailureReason:
 
         _drive(behaviour.get_mechs_info())
 
-        assert behaviour._context.state.last_failure_reason == "no_tools_in_manifests"
+        assert (
+            behaviour._context.state.last_failure_reason == "no_usable_tools_in_mechs"
+        )
 
     def test_clears_failure_reason_on_success(self) -> None:
         """A successful round leaves `last_failure_reason` as None."""
@@ -643,10 +648,10 @@ class TestLastFailureReason:
         assert result is None
         assert behaviour._context.state.last_failure_reason == "pinned_mechs_offline"
 
-    def test_writes_pinned_mechs_no_tools_when_pinned_visible_but_no_tools(
+    def test_writes_pinned_mechs_no_usable_tools_when_pinned_visible_but_no_tools(
         self,
     ) -> None:
-        """Pinned mech visible but with an empty manifest writes `pinned_mechs_no_tools`."""
+        """Pinned mech visible but with an empty manifest writes `pinned_mechs_no_usable_tools`."""
         behaviour = _make_mech_info_behaviour()
         api = _setup_api(behaviour)
         # First CID ("good") advertises tool_x; second CID ("pinned") has
@@ -679,7 +684,10 @@ class TestLastFailureReason:
             result = _drive(behaviour.get_mechs_info())
 
         assert result is None
-        assert behaviour._context.state.last_failure_reason == "pinned_mechs_no_tools"
+        assert (
+            behaviour._context.state.last_failure_reason
+            == "pinned_mechs_no_usable_tools"
+        )
 
     def test_pinned_mech_in_mech_info_does_not_trip_pinned_mechs_offline(self) -> None:
         """When a pinned address IS visible, no failure reason is written."""

--- a/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_mech_info_behaviour.py
@@ -91,14 +91,12 @@ def _wire_get_http_response(
 def _setup_api(
     behaviour: MechInformationBehaviour,
     valid_mechs: Optional[FrozenSet[str]] = None,
-    valid_tools: Optional[FrozenSet[str]] = None,
     **overrides: Any,
 ) -> MagicMock:
     """Set up a behaviour with mocked context.params and mech_tools_api."""
     behaviour._context.params = MagicMock()
     behaviour._context.params.ipfs_address = "https://ipfs.io/"
     behaviour._context.params.valid_mechs = valid_mechs or frozenset()
-    behaviour._context.params.valid_tools = valid_tools or frozenset()
 
     api = MagicMock()
     api.__dict__["_frozen"] = True
@@ -166,12 +164,9 @@ class TestPopulateTools:
         assert called["count"] == 0
 
     def test_populates_tools_from_http_response(self) -> None:
-        """Tools fetched via HTTP intersected with valid_tools allowlist."""
+        """Manifest tools are surfaced verbatim onto each mech's relevant_tools."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(
-            behaviour,
-            valid_tools=frozenset({"tool_a", "tool_b"}),
-        )
+        api = _setup_api(behaviour)
         api.process_response.return_value = ["tool_a", "tool_b", "tool_c"]
 
         mech = _make_mech_info(relevant_tools=set())
@@ -180,7 +175,7 @@ class TestPopulateTools:
         result = _drive(behaviour.populate_tools([mech]))
 
         assert result is True
-        assert mech.relevant_tools == {"tool_a", "tool_b"}
+        assert mech.relevant_tools == {"tool_a", "tool_b", "tool_c"}
         api.reset_retries.assert_called_once()
 
     def test_returns_false_on_transient_error(self) -> None:
@@ -302,7 +297,7 @@ class TestCidGrouping:
     def test_shared_cid_fetched_once_for_all_mechs(self) -> None:
         """N mechs with identical metadata_str result in a single HTTP fetch."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_x", "tool_y"}))
+        api = _setup_api(behaviour)
         api.process_response.return_value = ["tool_x", "tool_y"]
 
         mechs = [
@@ -331,10 +326,7 @@ class TestCidGrouping:
     def test_distinct_cids_fetched_separately(self) -> None:
         """Each distinct CID gets its own HTTP fetch."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(
-            behaviour,
-            valid_tools=frozenset({"tool_a", "tool_b"}),
-        )
+        api = _setup_api(behaviour)
         api.process_response.side_effect = [["tool_a"], ["tool_b"]]
 
         mech_a = _make_mech_info(
@@ -465,10 +457,7 @@ class TestGetMechsInfo:
     def test_partial_success_returns_serialized_json(self) -> None:
         """One good mech + one broken mech returns JSON; broken has empty tools."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(
-            behaviour,
-            valid_tools=frozenset({"tool_good"}),
-        )
+        api = _setup_api(behaviour)
         api.process_response.side_effect = [["tool_good"], None]
         api.is_permanent_error.return_value = True
         api.url = "http://test/broken"
@@ -526,39 +515,6 @@ class TestGetMechsInfo:
         assert "0xbroken" in behaviour._failed_mechs
 
 
-class TestAllowlistIntersect:
-    """Tests for the `valid_tools` allowlist intersect in populate_tools."""
-
-    def test_drops_metadata_tools_not_in_allowlist(self) -> None:
-        """Tools present in IPFS metadata but absent from `valid_tools` are dropped."""
-        behaviour = _make_mech_info_behaviour()
-        api = _setup_api(
-            behaviour,
-            valid_tools=frozenset({"tool_a"}),
-        )
-        api.process_response.return_value = ["tool_a", "tool_b", "tool_c"]
-
-        mech = _make_mech_info(relevant_tools=set())
-        _wire_get_http_response(behaviour, [MagicMock()])
-
-        _drive(behaviour.populate_tools([mech]))
-
-        assert mech.relevant_tools == {"tool_a"}
-
-    def test_empty_valid_tools_yields_empty_relevant_tools(self) -> None:
-        """An empty `valid_tools` set produces no relevant tools for any mech."""
-        behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset())
-        api.process_response.return_value = ["tool_a", "tool_b"]
-
-        mech = _make_mech_info(relevant_tools=set())
-        _wire_get_http_response(behaviour, [MagicMock()])
-
-        _drive(behaviour.populate_tools([mech]))
-
-        assert mech.relevant_tools == set()
-
-
 class TestLastFailureReason:
     """Tests for `last_failure_reason` writes from get_mechs_info."""
 
@@ -611,11 +567,11 @@ class TestLastFailureReason:
 
         assert behaviour._context.state.last_failure_reason == "valid_mech_list_empty"
 
-    def test_writes_no_overlap_when_valid_tools_empty(self) -> None:
-        """Empty `valid_tools` writes `no_overlap_with_valid_tools`."""
+    def test_writes_no_tools_in_manifests_when_all_manifests_empty(self) -> None:
+        """All manifests returning an empty tools list writes `no_tools_in_manifests`."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset())
-        api.process_response.return_value = ["tool_a"]
+        api = _setup_api(behaviour)
+        api.process_response.return_value = []
 
         mech = _make_mech_info(address="0xmech1", relevant_tools=set())
 
@@ -629,41 +585,14 @@ class TestLastFailureReason:
 
         _drive(behaviour.get_mechs_info())
 
-        assert (
-            behaviour._context.state.last_failure_reason
-            == "no_overlap_with_valid_tools"
-        )
-
-    def test_writes_no_overlap_when_metadata_disjoint_from_valid_tools(self) -> None:
-        """Non-empty `valid_tools` that doesn't intersect manifest writes the same reason."""
-        behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_x"}))
-        api.process_response.return_value = ["tool_a", "tool_b"]
-
-        mech = _make_mech_info(address="0xmech1", relevant_tools=set())
-
-        def mock_fetch_mechs_info() -> Generator[None, None, List[MechInfo]]:
-            behaviour._fetch_status = FetchStatus.SUCCESS
-            yield
-            return [mech]
-
-        behaviour.fetch_mechs_info = mock_fetch_mechs_info  # type: ignore[method-assign]
-        _wire_get_http_response(behaviour, [MagicMock()])
-
-        _drive(behaviour.get_mechs_info())
-
-        assert mech.relevant_tools == set()
-        assert (
-            behaviour._context.state.last_failure_reason
-            == "no_overlap_with_valid_tools"
-        )
+        assert behaviour._context.state.last_failure_reason == "no_tools_in_manifests"
 
     def test_clears_failure_reason_on_success(self) -> None:
         """A successful round leaves `last_failure_reason` as None."""
         behaviour = _make_mech_info_behaviour()
         behaviour._context.state.last_failure_reason = "stale_reason"
 
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_a"}))
+        api = _setup_api(behaviour)
         api.process_response.return_value = ["tool_a"]
 
         mech = _make_mech_info(address="0xmech1", relevant_tools=set())
@@ -689,7 +618,7 @@ class TestLastFailureReason:
     def test_writes_pinned_mechs_offline_when_pin_not_in_mech_info(self) -> None:
         """Pinned addresses absent from this round's mech_info write `pinned_mechs_offline`."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_a"}))
+        api = _setup_api(behaviour)
         api.process_response.return_value = ["tool_a"]
 
         mech = _make_mech_info(address="0xa", relevant_tools=set())
@@ -714,15 +643,16 @@ class TestLastFailureReason:
         assert result is None
         assert behaviour._context.state.last_failure_reason == "pinned_mechs_offline"
 
-    def test_writes_pinned_mechs_no_valid_tools_when_pinned_visible_but_no_tools(
+    def test_writes_pinned_mechs_no_tools_when_pinned_visible_but_no_tools(
         self,
     ) -> None:
-        """Pinned mech visible but with no tools in `valid_tools` writes `pinned_mechs_no_valid_tools`."""
+        """Pinned mech visible but with an empty manifest writes `pinned_mechs_no_tools`."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_x"}))
-        # First CID ("good") advertises tool_x; second CID ("pinned")
-        # advertises tool_a — only `good` ends up with relevant_tools.
-        api.process_response.side_effect = [["tool_x"], ["tool_a"]]
+        api = _setup_api(behaviour)
+        # First CID ("good") advertises tool_x; second CID ("pinned") has
+        # an empty manifest tools list -- only `good` ends up with
+        # relevant_tools and the pinned mech is quarantined empty.
+        api.process_response.side_effect = [["tool_x"], []]
 
         good = _make_mech_info(
             address="0xgood", metadata_str="good", relevant_tools=set()
@@ -749,15 +679,12 @@ class TestLastFailureReason:
             result = _drive(behaviour.get_mechs_info())
 
         assert result is None
-        assert (
-            behaviour._context.state.last_failure_reason
-            == "pinned_mechs_no_valid_tools"
-        )
+        assert behaviour._context.state.last_failure_reason == "pinned_mechs_no_tools"
 
     def test_pinned_mech_in_mech_info_does_not_trip_pinned_mechs_offline(self) -> None:
         """When a pinned address IS visible, no failure reason is written."""
         behaviour = _make_mech_info_behaviour()
-        api = _setup_api(behaviour, valid_tools=frozenset({"tool_a"}))
+        api = _setup_api(behaviour)
         api.process_response.return_value = ["tool_a"]
 
         mech = _make_mech_info(address="0xa", relevant_tools=set())


### PR DESCRIPTION
## Summary

- Per-mech `relevant_tools` now carries the full IPFS manifest tool set; the skill no longer pre-filters against an operator-curated `valid_tools` allowlist.
- The `valid_tools` param is removed entirely from `mech_interact_abci` -- consumers (e.g. trader's `decision_maker_abci`) become responsible for tool-suitability decisions.
- Two `last_failure_reason` strings renamed to reflect the new trigger conditions: `no_overlap_with_valid_tools` -> `no_tools_in_manifests`, `pinned_mechs_no_valid_tools` -> `pinned_mechs_no_tools`.

## Why

`relevant_tools` mixing transport (what the mech declares) with policy (what the operator authorises) made it impossible for downstream consumers to reason about which prediction tools the marketplace actually offers vs. which the operator allowlisted. Splitting the concern cleanly lets the consumer apply richer, content-based filters (e.g. trader's new `is_prediction_tool` classifier reads the actual manifest `toolMetadata` to decide).

## Cross-fleet impact

Audit confirmed only **trader** consumes `mech.relevant_tools` (see `decision_maker_abci/behaviours/tool_selection.py`). market-resolver depends on `mech_interact_abci` for transport but hardcodes a single tool; market-creator does not compose the skill. The trader companion PR replaces the allowlist with a tool-suitability classifier.

## Test plan

- [x] `tomte tox -e isort,black,flake8,mypy,darglint` all green
- [x] Pylint clean on touched files (10/10)
- [x] `autonomy analyse docstrings --update` no diff
- [x] `autonomy packages lock` produces a single hash bump (`mech_interact_abci`)
- [x] `pytest packages/valory/skills/mech_interact_abci/tests/` 450 passed at 100% coverage
- [ ] `mech-interact` CI green
- [ ] Downstream trader PR builds and passes against the new CID

## Breaking changes

Documented in `UPGRADING.md`:

1. The `valid_tools` param on `mech_interact_abci` is removed; any overlay that still sets it will fail to load. Move the override into the consumer skill that needs it.
2. `last_failure_reason` values renamed: `no_overlap_with_valid_tools` -> `no_tools_in_manifests`, `pinned_mechs_no_valid_tools` -> `pinned_mechs_no_tools`. Consumers that switch on these strings must update.

## Test churn

- `TestAllowlistIntersect` class deleted (premise gone).
- `test_writes_no_overlap_when_metadata_disjoint_from_valid_tools` deleted (unreachable now).
- `test_writes_no_overlap_when_valid_tools_empty` repurposed to `test_writes_no_tools_in_manifests_when_all_manifests_empty`.
- `test_writes_pinned_mechs_no_valid_tools_when_pinned_visible_but_no_tools` renamed and adapted.