### PR TITLE
feat(offchain): offchain dispatch branch — config foundation [WS-3]

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeign6u6635cpp7z2rws7uaaxgzvyokdyzztnadmivbt2qsvw2q2vza",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeib6wigs3ufiuzkj6twlthcya67lswm3qosikrg4ez7jjgkam4kz5m",
         "contract/valory/subscription_provider/0.1.0": "bafybeia7fmpemztyjwu4pu4p3q2udy7ymrxz4p5eklegdlc2bgnfi2zoae",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeibjv7pifobocxlty2ntoe35jyhp4hn3ydqjfzsicu47m4jtb7woum"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibyw26yuz2iw6dp25qxwerpfrl2vogecwrychig6y6ouym3z2hixi"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeign6u6635cpp7z2rws7uaaxgzvyokdyzztnadmivbt2qsvw2q2vza",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeib6wigs3ufiuzkj6twlthcya67lswm3qosikrg4ez7jjgkam4kz5m",
         "contract/valory/subscription_provider/0.1.0": "bafybeia7fmpemztyjwu4pu4p3q2udy7ymrxz4p5eklegdlc2bgnfi2zoae",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibjv7pifobocxlty2ntoe35jyhp4hn3ydqjfzsicu47m4jtb7woum"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/valory/skills/mech_interact_abci/models.py
+++ b/packages/valory/skills/mech_interact_abci/models.py
@@ -232,11 +232,28 @@ class MechMarketplaceConfig:
     priority_mech_service_id: int = 975
     requester_staking_instance_address: Optional[str] = NULL_ADDRESS
     use_dynamic_mech_selection: bool = True
+    # Off-chain dispatch (ships dark). False = today's on-chain MechMarketplace
+    # request, bit-for-bit unchanged. True engages the off-chain branch: the
+    # request is HTTP-POSTed to the mech and the response is polled, instead of
+    # being submitted/settled on-chain. ``offchain_url`` is the static fallback
+    # endpoint; when unset the URL is discovered per-mech from the on-chain
+    # manifest (see OFFCHAIN follow-up).
+    use_offchain: bool = False
+    offchain_url: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
         if self.response_timeout <= 0:
             raise ValueError("response_timeout must be positive")
+        if (
+            self.use_offchain
+            and not self.offchain_url
+            and not self.use_dynamic_mech_selection
+        ):
+            raise ValueError(
+                "use_offchain requires either offchain_url or "
+                "use_dynamic_mech_selection (to discover the mech's URL)"
+            )
 
 
 class MechParams(BaseParams):

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -29,7 +29,7 @@ fingerprint:
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeidwg2xei3fbrhe4qtr6c7ngpnjdpmfi6p2wpnkx5ig76schegiuv4
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
-  states/base.py: bafybeihbdsikdzhufjxd67swccltagv3ye6wzgorcx45uo3a65yoiquzna
+  states/base.py: bafybeidbgbg5nxenicvpx5tpz44fasypznm6vevo2aj5wm7n5dn5gg3p2i
   states/final_states.py: bafybeiaclul6oq3wtktpwwutgnzw4qi3untxqgnc34cofsxl3ejampou6q
   states/mech_info.py: bafybeihbbas6sjgcidewq623kvev4yxxrprvjmnhrgqxhpuazq6o3cmlpq
   states/mech_version.py: bafybeig62u4mklkod7gz7h2sh5ytm42nnryltyqaze2w52ovjaa6q7ogma

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -25,11 +25,11 @@ fingerprint:
   graph_tooling/queries/mechs_info.py: bafybeifklh73m2zkd447f6e3nk6xsv53l5eg4xip3rk6gyi6s6ptuivux4
   graph_tooling/requests.py: bafybeiblfdl22brohgmholbcir3f344as5nk6fwnwuljfc7rovd6dnifea
   handlers.py: bafybeifksdx5y5cod6mdnekqsjr36voedjlc3wjp2as4or5ltvl4mkyj5e
-  models.py: bafybeibtfcfdpeaykjgaxwc7fzke4n5yotwdxj2zr2qkqyoiowhrqcogpq
+  models.py: bafybeiahay6q5ekfyfff5upt24qkmzcptfhydw3eztmgwuj27erzzi2nc4
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeidwg2xei3fbrhe4qtr6c7ngpnjdpmfi6p2wpnkx5ig76schegiuv4
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
-  states/base.py: bafybeifoqrdygz46p3ibmqdbk3fmbo5jjlpkiund4fm5izn64qjejtnbpi
+  states/base.py: bafybeihbdsikdzhufjxd67swccltagv3ye6wzgorcx45uo3a65yoiquzna
   states/final_states.py: bafybeiaclul6oq3wtktpwwutgnzw4qi3untxqgnc34cofsxl3ejampou6q
   states/mech_info.py: bafybeihbbas6sjgcidewq623kvev4yxxrprvjmnhrgqxhpuazq6o3cmlpq
   states/mech_version.py: bafybeig62u4mklkod7gz7h2sh5ytm42nnryltyqaze2w52ovjaa6q7ogma
@@ -52,7 +52,7 @@ fingerprint:
   tests/test_graph_tooling.py: bafybeiaxihwxdhsjodefdbu42qibeqyhexdob3sqfs5hyo5ylgg7xzpzg4
   tests/test_handlers.py: bafybeihvo4mw3f3oizodlnysaw5nyup7rd3pm4zt2xkaa7nj6rr62vbjhq
   tests/test_mech_info_behaviour.py: bafybeiakoslt7wd6wqlchlumyutng6ayez3f3mafjmahu3kv7xddiqi6si
-  tests/test_models.py: bafybeid5izwmvai4a7lnmn4ru3f2c2xjuu45wlkil6b6v6gedxuxsrulia
+  tests/test_models.py: bafybeihfryofyix6u34upb4lfck4ccwep4khz6y2abkgsnx57jnuats3ly
   tests/test_payloads.py: bafybeibjkrdwkxqw73d7eaxwtqepigi4gutkvqaxqhj3os5nsmjffqkc4y
   tests/test_request_behaviour.py: bafybeiflipc3xfuaaas36bnkbg632d3kzd2qkp4e5vvdyui3y77u7fo7ue
   tests/test_response_behaviour.py: bafybeih2idnguntytqccjcavb5yvr4nlacw4nsyuc6pv5p2mo4nckpm5au
@@ -213,6 +213,8 @@ models:
         mech_marketplace_address: '0x0000000000000000000000000000000000000000'
         priority_mech_address: '0x0000000000000000000000000000000000000000'
         response_timeout: 300
+        use_offchain: false
+        offchain_url: null
       deliveries_lookback_days: 30
       valid_mechs: []
       penalize_mech_time_window: 1800

--- a/packages/valory/skills/mech_interact_abci/states/base.py
+++ b/packages/valory/skills/mech_interact_abci/states/base.py
@@ -42,14 +42,6 @@ from packages.valory.skills.transaction_settlement_abci.rounds import (
 
 SERIALIZED_EMPTY_LIST = "[]"
 METADATA_FIELD = "metadata"
-
-# Off-chain dispatch `last_failure_reason` values, surfaced so operators and
-# downstream skills can branch on a stable label when the off-chain path
-# exhausts its options (see the off-chain request/response behaviours).
-OFFCHAIN_ALL_FAILED = "offchain_all_failed"
-OFFCHAIN_402_INSUFFICIENT = "offchain_402_insufficient"
-OFFCHAIN_503_ALL_MECHS = "offchain_503_all_mechs"
-OFFCHAIN_TIMEOUT_ALL_MECHS = "offchain_timeout_all_mechs"
 BLOCK_TIMESTAMP_FIELD = "blockTimestamp"
 METADATA_PREFIX_SIZE = 2
 MACHINE_EPS = 1e-9
@@ -62,6 +54,14 @@ LAPLACE_SMOOTHING_BETA = 1
 COLD_START_LIVENESS = LAPLACE_SMOOTHING_ALPHA / (
     LAPLACE_SMOOTHING_ALPHA + LAPLACE_SMOOTHING_BETA
 )
+
+# Off-chain dispatch `last_failure_reason` values, surfaced so operators and
+# downstream skills can branch on a stable label when the off-chain path
+# exhausts its options (see the off-chain request/response behaviours).
+OFFCHAIN_ALL_FAILED = "offchain_all_failed"
+OFFCHAIN_402_INSUFFICIENT = "offchain_402_insufficient"
+OFFCHAIN_503_ALL_MECHS = "offchain_503_all_mechs"
+OFFCHAIN_TIMEOUT_ALL_MECHS = "offchain_timeout_all_mechs"
 
 NestedSubgraphItemType = List[Dict[str, Any]]
 

--- a/packages/valory/skills/mech_interact_abci/states/base.py
+++ b/packages/valory/skills/mech_interact_abci/states/base.py
@@ -42,6 +42,14 @@ from packages.valory.skills.transaction_settlement_abci.rounds import (
 
 SERIALIZED_EMPTY_LIST = "[]"
 METADATA_FIELD = "metadata"
+
+# Off-chain dispatch `last_failure_reason` values, surfaced so operators and
+# downstream skills can branch on a stable label when the off-chain path
+# exhausts its options (see the off-chain request/response behaviours).
+OFFCHAIN_ALL_FAILED = "offchain_all_failed"
+OFFCHAIN_402_INSUFFICIENT = "offchain_402_insufficient"
+OFFCHAIN_503_ALL_MECHS = "offchain_503_all_mechs"
+OFFCHAIN_TIMEOUT_ALL_MECHS = "offchain_timeout_all_mechs"
 BLOCK_TIMESTAMP_FIELD = "blockTimestamp"
 METADATA_PREFIX_SIZE = 2
 MACHINE_EPS = 1e-9

--- a/packages/valory/skills/mech_interact_abci/tests/test_models.py
+++ b/packages/valory/skills/mech_interact_abci/tests/test_models.py
@@ -99,6 +99,48 @@ class TestMechMarketplaceConfig:
         assert config.priority_mech_address == "0xpriority"
         assert config.use_dynamic_mech_selection is False
 
+    def test_use_offchain_defaults_off(self) -> None:
+        """Off-chain dispatch ships dark: defaults to disabled with no URL."""
+        config = MechMarketplaceConfig(
+            mech_marketplace_address="0xmarket",
+            response_timeout=30,
+        )
+        assert config.use_offchain is False
+        assert config.offchain_url is None
+
+    def test_use_offchain_with_static_url(self) -> None:
+        """A static offchain_url satisfies the off-chain config."""
+        config = MechMarketplaceConfig(
+            mech_marketplace_address="0xmarket",
+            response_timeout=30,
+            use_offchain=True,
+            offchain_url="https://mech.example/",
+            use_dynamic_mech_selection=False,
+        )
+        assert config.use_offchain is True
+        assert config.offchain_url == "https://mech.example/"
+
+    def test_use_offchain_with_dynamic_selection(self) -> None:
+        """Dynamic selection is allowed without a static URL (discovered per-mech)."""
+        config = MechMarketplaceConfig(
+            mech_marketplace_address="0xmarket",
+            response_timeout=30,
+            use_offchain=True,
+            use_dynamic_mech_selection=True,
+        )
+        assert config.use_offchain is True
+        assert config.offchain_url is None
+
+    def test_use_offchain_without_url_or_dynamic_raises(self) -> None:
+        """Off-chain needs either a static URL or dynamic discovery."""
+        with pytest.raises(ValueError, match="use_offchain requires"):
+            MechMarketplaceConfig(
+                mech_marketplace_address="0xmarket",
+                response_timeout=30,
+                use_offchain=True,
+                use_dynamic_mech_selection=False,
+            )
+
 
 class TestSharedStateLastFailureReason:
     """Tests for SharedState.last_failure_reason."""


### PR DESCRIPTION
## WS-3 — mech-interact offchain dispatch (the plan's "dominant cost")

Part of the Marketplace/API offchain migration (Thread 1, requester side). Targets mech#454's server contract (structured 402, `/send_signed_requests`, `/fetch_offchain_info`, bare-file CID) and pairs with mech-client#241.

**This PR lands the foundation; the behaviour + FSM work follows (scoped below).** Ships dark — `use_offchain` defaults False, so the on-chain MechMarketplace path is bit-for-bit unchanged.

### In this PR (foundation)
- **`MechMarketplaceConfig`**: `use_offchain` (default False) + `offchain_url`, with validation (offchain needs a static URL *or* dynamic selection to discover the mech's URL).
- **`states/base`**: the offchain `last_failure_reason` constants — `offchain_all_failed`, `offchain_402_insufficient`, `offchain_503_all_mechs`, `offchain_timeout_all_mechs`.
- **`skill.yaml`**: the two config args.
- **Tests** for the config (default-off / static-url / dynamic / no-url-no-dynamic error). 38 model tests green; black-clean; relocked `mech_interact_abci` only (no third-party churn).

### Full design (for the follow-ups)
When `use_offchain` is true, the request/response behaviours diverge from the on-chain path at these points (mapped):

**Request side** (`behaviours/request.py`):
1. **Selection** (`get_priority_mech_address`, ~565): resolve the mech's HTTP URL — from `offchain_url`, or discovered per-mech from the on-chain manifest (`Service.metadata_str`) under dynamic selection.
2. **Build/dispatch** (`_build_request_data`/`_prepare_safe_tx`, ~901/947): instead of uploading to IPFS + building the multisend tx, compute the request CID locally (bare-file, matching the mech), sign the `request_id`, and **HTTP POST** to the mech's `/send_signed_requests` (`get_http_response`).
3. **402 / failover**: parse the structured 402 → set `offchain_402_insufficient`; on timeout/503 → re-sign for the next ranked mech **at the same on-chain nonce** (client-side retry, *not* step-in) → `offchain_503_all_mechs` / `offchain_timeout_all_mechs` / `offchain_all_failed` when exhausted.
4. **Payload** (`async_act`, ~995): record the pending responses for polling; emit no on-chain tx.

**Response side** (`behaviours/response.py`, `_get_response` ~468): point the response API at the mech's `/fetch_offchain_info` and poll, instead of the IPFS gateway.

**Consensus model (to confirm):** the offchain POST is a per-agent side-effect; the mech dedupes by `request_id` (same as #454's replay handling). Worth a team decision vs. a single-keeper POST.

### Follow-ups (checklist)
- [ ] Request behaviour: offchain sign + POST + 402/failover (gated on `use_offchain`).
- [ ] Response behaviour: offchain poll branch.
- [ ] Per-mech HTTP URL discovery from the on-chain manifest.
- [ ] **Composition FSM routing** (in the consuming agents — trader/market-creator, WS-4-adjacent): route the offchain request to the response round **skipping `TransactionSettlement`**. This is cross-repo and the main integration step.
- [ ] CID-path parity with the mech's bare-file `compute_cidv1` (benny's note on mech#454).

🤖 Generated with [Claude Code](https://claude.com/claude-code)