### PR TITLE
feat: add MechMetadata.extra_attributes for non-prompt tool params

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeign6u6635cpp7z2rws7uaaxgzvyokdyzztnadmivbt2qsvw2q2vza",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeib6wigs3ufiuzkj6twlthcya67lswm3qosikrg4ez7jjgkam4kz5m",
         "contract/valory/subscription_provider/0.1.0": "bafybeia7fmpemztyjwu4pu4p3q2udy7ymrxz4p5eklegdlc2bgnfi2zoae",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeidc4pbdvjw55nz5t5numf7crwuvz4t42y3z7b6jkqqcmafmnycfva"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -25,23 +25,23 @@
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",
         "protocol/valory/tendermint/0.1.0": "bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq",
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
-        "contract/valory/multisend/0.1.0": "bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeifzd3duzsvbl76wzippvkqqvtn3shf7p57n43ffduxbsdreu3q4oy",
-        "contract/valory/agent_registry/0.1.0": "bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe",
-        "contract/valory/service_registry/0.1.0": "bafybeihktixbuw7dz3oa2xzfvpuchbnid7eob224n3spm77xx2yj2wixcm",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne",
-        "contract/valory/erc20/0.1.0": "bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu",
-        "contract/valory/agent_mech/0.1.0": "bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne",
+        "contract/valory/multisend/0.1.0": "bafybeih73g7nltnmfqfa75qurljjk7xu7cvd3d2uzt4bqogcw5rgrrmu2m",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib63lr7rsd77nyo5iz4et2ali6z2y5lekfjg3za7lk4fnf4b2j2ue",
+        "contract/valory/agent_registry/0.1.0": "bafybeihndb57u3da2ollttbkm56te6ihekh5pesmxruk4sxn6psnz2ycri",
+        "contract/valory/service_registry/0.1.0": "bafybeiccha6qwov4pqsnnhnprldppaqlb7djcujcqqlmtgbukq4a5fmvvq",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeieaxcd3wrjxgw7yzmlbxr6tcwj3u7kiixb6fzu2shwy5hthzzyxuq",
+        "contract/valory/erc20/0.1.0": "bafybeidhafsjqsj7umr5mgb3v4t52sbcnwhlfk7hqgulbdvui4yhfrgrjy",
+        "contract/valory/agent_mech/0.1.0": "bafybeibjivg3evaj36qtgehbze5jmhjipn5qgzmdbucfmojimepvanfyei",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
         "connection/valory/ledger/0.19.0": "bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4",
-        "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
-        "connection/valory/ipfs/0.1.0": "bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta",
-        "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii",
-        "skill/valory/registration_abci/0.1.0": "bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
-        "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq"
+        "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
+        "connection/valory/ipfs/0.1.0": "bafybeicxrwakpakexuixxp6yo25sosikrjs4mvzfvzklpqk5fa3yy3hh5a",
+        "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeibvbfkmkqjidukhkzzz7nd33gna64hjhcn3blon5xcleilbt63zn4",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeiceijjjlvbq2tnadeqdrm7nka7gqgwzvmlgjuzbacgnkljry5h72a",
+        "skill/valory/registration_abci/0.1.0": "bafybeihkfla7hppssqk2dojuxjuy233jrilablud4avtazagt2javcihya",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeiakhczviqep47o5txatkdbzui6bk5o554cnspdkauapvmdykk2tkm",
+        "skill/valory/termination_abci/0.1.0": "bafybeibduc7hdi3xu7ahpumgew6es33jcadbrbipboyc7sbuyzds45fmve"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeign6u6635cpp7z2rws7uaaxgzvyokdyzztnadmivbt2qsvw2q2vza",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeib6wigs3ufiuzkj6twlthcya67lswm3qosikrg4ez7jjgkam4kz5m",
         "contract/valory/subscription_provider/0.1.0": "bafybeia7fmpemztyjwu4pu4p3q2udy7ymrxz4p5eklegdlc2bgnfi2zoae",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeifygdg3qsjxcjx23edulyjjdvqebqefpadvj6et46txmnjyz6cgi4"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeihn6ic3exr3umjl5kgmlos3d2sjy6rs3sfogvdtw5e5lenpjaxwou"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/agreement_store_manager/0.1.0": "bafybeign6u6635cpp7z2rws7uaaxgzvyokdyzztnadmivbt2qsvw2q2vza",
         "contract/valory/transfer_nft_condition/0.1.0": "bafybeib6wigs3ufiuzkj6twlthcya67lswm3qosikrg4ez7jjgkam4kz5m",
         "contract/valory/subscription_provider/0.1.0": "bafybeia7fmpemztyjwu4pu4p3q2udy7ymrxz4p5eklegdlc2bgnfi2zoae",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeidc4pbdvjw55nz5t5numf7crwuvz4t42y3z7b6jkqqcmafmnycfva"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeifygdg3qsjxcjx23edulyjjdvqebqefpadvj6et46txmnjyz6cgi4"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -25,23 +25,23 @@
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",
         "protocol/valory/tendermint/0.1.0": "bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq",
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
-        "contract/valory/multisend/0.1.0": "bafybeih73g7nltnmfqfa75qurljjk7xu7cvd3d2uzt4bqogcw5rgrrmu2m",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib63lr7rsd77nyo5iz4et2ali6z2y5lekfjg3za7lk4fnf4b2j2ue",
-        "contract/valory/agent_registry/0.1.0": "bafybeihndb57u3da2ollttbkm56te6ihekh5pesmxruk4sxn6psnz2ycri",
-        "contract/valory/service_registry/0.1.0": "bafybeiccha6qwov4pqsnnhnprldppaqlb7djcujcqqlmtgbukq4a5fmvvq",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeieaxcd3wrjxgw7yzmlbxr6tcwj3u7kiixb6fzu2shwy5hthzzyxuq",
-        "contract/valory/erc20/0.1.0": "bafybeidhafsjqsj7umr5mgb3v4t52sbcnwhlfk7hqgulbdvui4yhfrgrjy",
-        "contract/valory/agent_mech/0.1.0": "bafybeibjivg3evaj36qtgehbze5jmhjipn5qgzmdbucfmojimepvanfyei",
+        "contract/valory/multisend/0.1.0": "bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeifzd3duzsvbl76wzippvkqqvtn3shf7p57n43ffduxbsdreu3q4oy",
+        "contract/valory/agent_registry/0.1.0": "bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe",
+        "contract/valory/service_registry/0.1.0": "bafybeihktixbuw7dz3oa2xzfvpuchbnid7eob224n3spm77xx2yj2wixcm",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne",
+        "contract/valory/erc20/0.1.0": "bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu",
+        "contract/valory/agent_mech/0.1.0": "bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
         "connection/valory/ledger/0.19.0": "bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4",
-        "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
-        "connection/valory/ipfs/0.1.0": "bafybeicxrwakpakexuixxp6yo25sosikrjs4mvzfvzklpqk5fa3yy3hh5a",
-        "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeibvbfkmkqjidukhkzzz7nd33gna64hjhcn3blon5xcleilbt63zn4",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeiceijjjlvbq2tnadeqdrm7nka7gqgwzvmlgjuzbacgnkljry5h72a",
-        "skill/valory/registration_abci/0.1.0": "bafybeihkfla7hppssqk2dojuxjuy233jrilablud4avtazagt2javcihya",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeiakhczviqep47o5txatkdbzui6bk5o554cnspdkauapvmdykk2tkm",
-        "skill/valory/termination_abci/0.1.0": "bafybeibduc7hdi3xu7ahpumgew6es33jcadbrbipboyc7sbuyzds45fmve"
+        "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
+        "connection/valory/ipfs/0.1.0": "bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta",
+        "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii",
+        "skill/valory/registration_abci/0.1.0": "bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
+        "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq"
     }
 }

--- a/packages/valory/skills/mech_interact_abci/behaviours/request.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/request.py
@@ -632,7 +632,13 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
         # prompt/tool/nonce) so the tool reads them as run() kwargs, and drop
         # the wrapper key. With no extras this is byte-identical to asdict().
         payload = asdict(metadata)
-        payload.update(payload.pop("extra_attributes", None) or {})
+        extras = payload.pop("extra_attributes", None) or {}
+        clobbered = extras.keys() & payload.keys()
+        if clobbered:
+            self.context.logger.warning(
+                f"extra_attributes override reserved request keys: {clobbered}"
+            )
+        payload.update(extras)
         metadata_hash = yield from self.send_to_ipfs(
             self.metadata_filepath, payload, filetype=SupportedFiletype.JSON
         )

--- a/packages/valory/skills/mech_interact_abci/behaviours/request.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/request.py
@@ -628,8 +628,13 @@ class MechRequestBehaviour(MechInteractBaseBehaviour):
     ) -> WaitableConditionType:
         """Send Mech metadata to IPFS."""
         metadata = self._mech_requests.pop()
+        # Merge any extra tool parameters into the payload top-level (next to
+        # prompt/tool/nonce) so the tool reads them as run() kwargs, and drop
+        # the wrapper key. With no extras this is byte-identical to asdict().
+        payload = asdict(metadata)
+        payload.update(payload.pop("extra_attributes", None) or {})
         metadata_hash = yield from self.send_to_ipfs(
-            self.metadata_filepath, asdict(metadata), filetype=SupportedFiletype.JSON
+            self.metadata_filepath, payload, filetype=SupportedFiletype.JSON
         )
         if metadata_hash is None:
             return False

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   behaviours/mech_info.py: bafybeibwwabrnhgafubf5qrldiyqgjtp6byctlaaczxlvgjvndihjtwjue
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
-  behaviours/request.py: bafybeifhy47fhj3m5rfejy7kajr55sthmzqqydavz7vm5ep3x4v6p554nm
+  behaviours/request.py: bafybeicsozbqkys3wg73p6tjs2anrjmsjpmoe74msxj4uybkvrsgqcyxra
   behaviours/response.py: bafybeid474xrjitvkuv44nf2x2drfeuotyv2mzxvhegfh2t43qwee7enx4
   behaviours/round_behaviour.py: bafybeige7ajovc2u3vjb2elodqi47urfb5nms4felsx4b7jb3zaorimjv4
   dialogues.py: bafybeiachjgarkgv4hxprddn7dtb5h3q4qge72rc2kysmureooq5xggxxi
@@ -29,7 +29,7 @@ fingerprint:
   payloads.py: bafybeifsk2gvtxzg2qccsjhtxp26x6ioyg7inebayqn6zz4de3pfxqm4ja
   rounds.py: bafybeidwg2xei3fbrhe4qtr6c7ngpnjdpmfi6p2wpnkx5ig76schegiuv4
   states/__init__.py: bafybeibq6l52a6f6vnm273rfgqbps3mffmgzmgujcm5igomgtelgflo5xm
-  states/base.py: bafybeifoqrdygz46p3ibmqdbk3fmbo5jjlpkiund4fm5izn64qjejtnbpi
+  states/base.py: bafybeidrwdgd37hhqpccbo7n7nvs2k6yyzmfrtfxesw3zjiw5rhe3p4np4
   states/final_states.py: bafybeiaclul6oq3wtktpwwutgnzw4qi3untxqgnc34cofsxl3ejampou6q
   states/mech_info.py: bafybeihbbas6sjgcidewq623kvev4yxxrprvjmnhrgqxhpuazq6o3cmlpq
   states/mech_version.py: bafybeig62u4mklkod7gz7h2sh5ytm42nnryltyqaze2w52ovjaa6q7ogma
@@ -45,7 +45,7 @@ fingerprint:
   tests/behaviours/test_request.py: bafybeifng4uhlb3j6fg3wriwt2rvhqh3smwvfo5ugzqjdyt36uua6t3k7y
   tests/behaviours/test_response.py: bafybeibni7zx4m7n3wktmlxyab4olt4rnduqzhaltfl7n3exru3om5fymy
   tests/states/__init__.py: bafybeieo3txynlsaxtuqxvvhjyjn2hft3ztsnr5v6byoccqg2allecx2vm
-  tests/states/test_base.py: bafybeicjdo3ni56brz4ivgt4abi6v5izoa4rqclqezcnoumejwmavqqmde
+  tests/states/test_base.py: bafybeifpns6rui55g3wp7bep4jj5n42agafthffh76ztrw67exxnbjpjj4
   tests/test_base_behaviour.py: bafybeih33kcrhjqb3khr6gkhfhgaczzstgiehaajv2coieuqgtx2ijc3cu
   tests/test_behaviours.py: bafybeihsqjmxiossblhy4k643ylsslrhvvdqy7ozkgairlqllpl7oxklfi
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq
@@ -62,14 +62,14 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne
+- valory/gnosis_safe:0.1.0:bafybeieaxcd3wrjxgw7yzmlbxr6tcwj3u7kiixb6fzu2shwy5hthzzyxuq
 - valory/mech:0.1.0:bafybeid2v3rotkylgln5w2udm3nnmsrnw4g4nlkbwhqfwbte4kwlxup5l4
 - valory/mech_mm:0.1.0:bafybeiaez7w5ssgcmt5fqbue4oywhxmcojrnxqimzksuojsksxwaqvwo5u
-- valory/multisend:0.1.0:bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy
-- valory/erc20:0.1.0:bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu
-- valory/agent_mech:0.1.0:bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne
+- valory/multisend:0.1.0:bafybeih73g7nltnmfqfa75qurljjk7xu7cvd3d2uzt4bqogcw5rgrrmu2m
+- valory/erc20:0.1.0:bafybeidhafsjqsj7umr5mgb3v4t52sbcnwhlfk7hqgulbdvui4yhfrgrjy
+- valory/agent_mech:0.1.0:bafybeibjivg3evaj36qtgehbze5jmhjipn5qgzmdbucfmojimepvanfyei
 - valory/mech_marketplace_legacy:0.1.0:bafybeifkolgdeaoiveuppykvxkvja7c7pphn6jyivnk6x3bjl72rqpsogm
-- valory/agent_registry:0.1.0:bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe
+- valory/agent_registry:0.1.0:bafybeihndb57u3da2ollttbkm56te6ihekh5pesmxruk4sxn6psnz2ycri
 - valory/ierc1155:0.1.0:bafybeif3wfclopxa3panep4xzgodlfclgypm3balncxyuxbhhvgz7imulq
 - valory/nvm_balance_tracker_token:0.1.0:bafybeifwxkaobltpm77oh2b54kuclm4vtx2bzpuoowqfdemkex5gb5yyfa
 - valory/nvm_balance_tracker_native:0.1.0:bafybeibou3doazirk637cyey4o33pz7fpdm4hsgdj7vd2kctuqxtjgnmla
@@ -86,8 +86,8 @@ protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
-- valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
+- valory/abstract_round_abci:0.1.0:bafybeibvbfkmkqjidukhkzzz7nd33gna64hjhcn3blon5xcleilbt63zn4
+- valory/transaction_settlement_abci:0.1.0:bafybeiceijjjlvbq2tnadeqdrm7nka7gqgwzvmlgjuzbacgnkljry5h72a
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -62,14 +62,14 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeieaxcd3wrjxgw7yzmlbxr6tcwj3u7kiixb6fzu2shwy5hthzzyxuq
+- valory/gnosis_safe:0.1.0:bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne
 - valory/mech:0.1.0:bafybeid2v3rotkylgln5w2udm3nnmsrnw4g4nlkbwhqfwbte4kwlxup5l4
 - valory/mech_mm:0.1.0:bafybeiaez7w5ssgcmt5fqbue4oywhxmcojrnxqimzksuojsksxwaqvwo5u
-- valory/multisend:0.1.0:bafybeih73g7nltnmfqfa75qurljjk7xu7cvd3d2uzt4bqogcw5rgrrmu2m
-- valory/erc20:0.1.0:bafybeidhafsjqsj7umr5mgb3v4t52sbcnwhlfk7hqgulbdvui4yhfrgrjy
-- valory/agent_mech:0.1.0:bafybeibjivg3evaj36qtgehbze5jmhjipn5qgzmdbucfmojimepvanfyei
+- valory/multisend:0.1.0:bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy
+- valory/erc20:0.1.0:bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu
+- valory/agent_mech:0.1.0:bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne
 - valory/mech_marketplace_legacy:0.1.0:bafybeifkolgdeaoiveuppykvxkvja7c7pphn6jyivnk6x3bjl72rqpsogm
-- valory/agent_registry:0.1.0:bafybeihndb57u3da2ollttbkm56te6ihekh5pesmxruk4sxn6psnz2ycri
+- valory/agent_registry:0.1.0:bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe
 - valory/ierc1155:0.1.0:bafybeif3wfclopxa3panep4xzgodlfclgypm3balncxyuxbhhvgz7imulq
 - valory/nvm_balance_tracker_token:0.1.0:bafybeifwxkaobltpm77oh2b54kuclm4vtx2bzpuoowqfdemkex5gb5yyfa
 - valory/nvm_balance_tracker_native:0.1.0:bafybeibou3doazirk637cyey4o33pz7fpdm4hsgdj7vd2kctuqxtjgnmla
@@ -86,8 +86,8 @@ protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeibvbfkmkqjidukhkzzz7nd33gna64hjhcn3blon5xcleilbt63zn4
-- valory/transaction_settlement_abci:0.1.0:bafybeiceijjjlvbq2tnadeqdrm7nka7gqgwzvmlgjuzbacgnkljry5h72a
+- valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
+- valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   behaviours/mech_info.py: bafybeibwwabrnhgafubf5qrldiyqgjtp6byctlaaczxlvgjvndihjtwjue
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
-  behaviours/request.py: bafybeicsozbqkys3wg73p6tjs2anrjmsjpmoe74msxj4uybkvrsgqcyxra
+  behaviours/request.py: bafybeifbjs5t67ohxhxmmtx2xl42icbwv7tbeetxdfud2ey6cya2sxi26u
   behaviours/response.py: bafybeid474xrjitvkuv44nf2x2drfeuotyv2mzxvhegfh2t43qwee7enx4
   behaviours/round_behaviour.py: bafybeige7ajovc2u3vjb2elodqi47urfb5nms4felsx4b7jb3zaorimjv4
   dialogues.py: bafybeiachjgarkgv4hxprddn7dtb5h3q4qge72rc2kysmureooq5xggxxi
@@ -45,7 +45,7 @@ fingerprint:
   tests/behaviours/test_request.py: bafybeifng4uhlb3j6fg3wriwt2rvhqh3smwvfo5ugzqjdyt36uua6t3k7y
   tests/behaviours/test_response.py: bafybeibni7zx4m7n3wktmlxyab4olt4rnduqzhaltfl7n3exru3om5fymy
   tests/states/__init__.py: bafybeieo3txynlsaxtuqxvvhjyjn2hft3ztsnr5v6byoccqg2allecx2vm
-  tests/states/test_base.py: bafybeifpns6rui55g3wp7bep4jj5n42agafthffh76ztrw67exxnbjpjj4
+  tests/states/test_base.py: bafybeihinlkgkqxzlmubxsllyemrzpe5pexmquxoia4nngncn43l72472e
   tests/test_base_behaviour.py: bafybeih33kcrhjqb3khr6gkhfhgaczzstgiehaajv2coieuqgtx2ijc3cu
   tests/test_behaviours.py: bafybeihsqjmxiossblhy4k643ylsslrhvvdqy7ozkgairlqllpl7oxklfi
   tests/test_dialogues.py: bafybeicztq6kz273kpq6qtp4arh5btyovj7tiwcyy227bomblv52rx2rjq

--- a/packages/valory/skills/mech_interact_abci/states/base.py
+++ b/packages/valory/skills/mech_interact_abci/states/base.py
@@ -81,6 +81,10 @@ class MechMetadata:
     nonce: str
     schema_version: str = "2.0"
     request_context: Optional[Dict[str, Any]] = None
+    # Extra tool parameters, merged into the request payload top-level (next to
+    # prompt/tool/nonce) so the tool receives them as run() kwargs. Mirrors the
+    # mech-client `extra_attributes` channel. Defaults to None for back-compat.
+    extra_attributes: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/packages/valory/skills/mech_interact_abci/tests/states/test_base.py
+++ b/packages/valory/skills/mech_interact_abci/tests/states/test_base.py
@@ -730,6 +730,17 @@ class TestMechMetadata:
         meta = MechMetadata(prompt="q?", tool="t1", nonce="n1", request_context=ctx)
         assert meta.request_context == ctx
 
+    def test_default_extra_attributes_is_none(self) -> None:
+        """Test that extra_attributes defaults to None."""
+        meta = MechMetadata(prompt="q?", tool="t1", nonce="n1")
+        assert meta.extra_attributes is None
+
+    def test_explicit_extra_attributes(self) -> None:
+        """Test constructing with explicit extra_attributes."""
+        extra = {"topics": ["sports"], "num_questions": 1}
+        meta = MechMetadata(prompt="q?", tool="t1", nonce="n1", extra_attributes=extra)
+        assert meta.extra_attributes == extra
+
     def test_explicit_schema_version_override(self) -> None:
         """Test that schema_version can be explicitly overridden."""
         meta = MechMetadata(prompt="q?", tool="t1", nonce="n1", schema_version="3.0")

--- a/packages/valory/skills/mech_interact_abci/tests/states/test_base.py
+++ b/packages/valory/skills/mech_interact_abci/tests/states/test_base.py
@@ -741,6 +741,28 @@ class TestMechMetadata:
         meta = MechMetadata(prompt="q?", tool="t1", nonce="n1", extra_attributes=extra)
         assert meta.extra_attributes == extra
 
+    def test_payload_merges_extras_top_level_and_drops_wrapper(self) -> None:
+        """Extra attributes merge top-level into the request payload; wrapper dropped."""
+        meta = MechMetadata(
+            prompt="q?",
+            tool="t1",
+            nonce="n1",
+            extra_attributes={"topics": ["sports"], "num_questions": 1},
+        )
+        payload = asdict(meta)
+        payload.update(payload.pop("extra_attributes", None) or {})
+        assert "extra_attributes" not in payload
+        assert payload["topics"] == ["sports"]
+        assert payload["num_questions"] == 1
+
+    def test_payload_byte_identical_without_extras(self) -> None:
+        """With no extra_attributes the payload equals asdict() minus the wrapper key."""
+        meta = MechMetadata(prompt="q?", tool="t1", nonce="n1")
+        payload = asdict(meta)
+        payload.update(payload.pop("extra_attributes", None) or {})
+        expected = {k: v for k, v in asdict(meta).items() if k != "extra_attributes"}
+        assert payload == expected
+
     def test_explicit_schema_version_override(self) -> None:
         """Test that schema_version can be explicitly overridden."""
         meta = MechMetadata(prompt="q?", tool="t1", nonce="n1", schema_version="3.0")


### PR DESCRIPTION
## Summary

Mech tools receive their inputs as `run(**kwargs)` — the executor spreads the request JSON's top-level keys. **mech-client** already lets callers add arbitrary top-level params via `extra_attributes` (`metadata.update(extra_attributes)`), but **`mech_interact_abci` uploaded only the fixed `MechMetadata` fields** (`asdict`), so a tool whose inputs are *structured params* rather than a natural-language `prompt` had no channel.

This adds that channel, minimally and backward-compatibly.

## Changes
- `MechMetadata`: new optional field `extra_attributes: Optional[Dict[str, Any]] = None`.
- `RequestBehaviour._send_metadata_to_ipfs`: merge `extra_attributes` into the IPFS payload **top-level** (next to `prompt`/`tool`/`nonce`) and drop the wrapper key:
  ```python
  payload = asdict(metadata)
  payload.update(payload.pop("extra_attributes", None) or {})
  ```
- 2 unit tests for the new field.

## Backward compatibility
With no `extra_attributes` set (the default), `payload.pop(...) or {}` is empty and the uploaded payload is **byte-identical** to the previous `asdict(metadata)`. Existing consumers (trader, market-resolver) are pinned to their own `mech_interact_abci` CID and are unaffected until they choose to bump.

`request_context` is **unchanged** — it remains the analysis/benchmark-context channel (uploaded for data analysis, not read as tool input). `extra_attributes` is the dedicated tool-parameter channel, mirroring mech-client.

## Motivation
The `propose-question` tool (market-creator) takes structured params (`topics`, `num_questions`, `resolution_time`) and currently has to smuggle them through a JSON-encoded `prompt`. With this change it passes them via `extra_attributes` → top-level kwargs → the tool reads them directly (no tool change).

## Test plan
- [x] `TestMechMetadata` (12 tests) + request-behaviour suite (33) pass
- [x] `autonomy packages lock` idempotent, no fingerprint pollution
- [ ] CI green