### PR TITLE
fix(offchain): warn on missing 'result' key in ok envelope; test coverage

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -16,7 +16,7 @@
         "contract/valory/balance_tracker_fixed_price_token/0.1.0": "bafybeienpn5nb7mgiw5uitm5mjwcgc2xd7bzx5rxu2mqsvjziwvlg6poxa",
         "contract/valory/balance_tracker_fixed_price_native/0.1.0": "bafybeifobvptvc7mkrztfij664dqqegl6qi32773zewvyuftes32faemw4",
         "contract/valory/mech_marketplace/0.1.0": "bafybeieadbmhzndxe6jcfwujcpjrljpc5kfwffkd3zzpg75uxksufn4l3i",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeic3ar66g5gwty33wsx37lilvwxddecqbj6ql5g4m6ago3yqodykju"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeibh3hxc76n3tc2kq2pqq2uqtgjcd2qhvoixxr7hwzdvm4g65tp6r4"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i",
@@ -28,23 +28,23 @@
         "protocol/valory/abci/0.1.0": "bafybeiak4pwac3pwjtd7weskxdhkrcopckr32vtazfbuteu6yqjkwarpte",
         "protocol/valory/tendermint/0.1.0": "bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq",
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
-        "contract/valory/multisend/0.1.0": "bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeifzd3duzsvbl76wzippvkqqvtn3shf7p57n43ffduxbsdreu3q4oy",
-        "contract/valory/agent_registry/0.1.0": "bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe",
-        "contract/valory/service_registry/0.1.0": "bafybeihktixbuw7dz3oa2xzfvpuchbnid7eob224n3spm77xx2yj2wixcm",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne",
-        "contract/valory/erc20/0.1.0": "bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu",
-        "contract/valory/agent_mech/0.1.0": "bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne",
+        "contract/valory/multisend/0.1.0": "bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeigr6ugkp6bxwnbkecktotekcjihabb6eudh3bgcnjfdorwosygile",
+        "contract/valory/agent_registry/0.1.0": "bafybeia6gfxdfpr4apeqd6s4777d7yf6qya2slu3ccqmwiapxe72ckvsiq",
+        "contract/valory/service_registry/0.1.0": "bafybeicbfffywnaaehptzasxsdoyguuurpleirsnor5xf7rqk57isjkury",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju",
+        "contract/valory/erc20/0.1.0": "bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq",
+        "contract/valory/agent_mech/0.1.0": "bafybeidrkuruvewbi7xmi7py26ylgpcslmr5yuyu4tw6o7uekolmsj2zqa",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
         "connection/valory/ledger/0.19.0": "bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4",
         "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
-        "connection/valory/ipfs/0.1.0": "bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta",
+        "connection/valory/ipfs/0.1.0": "bafybeidob3tcdebjbm4ovwqoz4v2egf7nvoui3hu5on4o3apfchr6rpwwa",
         "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii",
-        "skill/valory/registration_abci/0.1.0": "bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
-        "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq"
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeibkhvngknsnluenxcxvzgs7s6z6ai62yfkce37nfwltge6aujplm4",
+        "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
+        "skill/valory/termination_abci/0.1.0": "bafybeibcuvavnh67e6araxhuogi4hgylnodc7hieqfcbjjjeojuel3tndq"
     }
 }

--- a/packages/valory/skills/mech_interact_abci/behaviours/offchain_response.py
+++ b/packages/valory/skills/mech_interact_abci/behaviours/offchain_response.py
@@ -268,9 +268,21 @@ class OffchainResponsePoller:
             # failure the envelope JSON-parses but has no `p_yes`, hitting
             # KeyError in `PredictionResponse.__init__`.
             envelope = payload.get("response")
-            inner_result = (
-                envelope.get("result") if isinstance(envelope, dict) else envelope
-            )
+            if isinstance(envelope, dict):
+                if "result" not in envelope:
+                    # Schema drift: the ok envelope should always carry a
+                    # `result` key. Falling through with None would look
+                    # indistinguishable from a routine tool failure
+                    # (target.error becomes "Unknown"); flag it so the
+                    # drift is visible rather than a fake failed prediction.
+                    self._logger.warning(
+                        "Offchain 'ok' envelope missing 'result' key; "
+                        "keys=%s. Treating as a failed poll.",
+                        sorted(envelope.keys()),
+                    )
+                inner_result = envelope.get("result")
+            else:
+                inner_result = envelope
             return _PollSnapshot(
                 status="ok",
                 result=self._serialise_result(inner_result),

--- a/packages/valory/skills/mech_interact_abci/skill.yaml
+++ b/packages/valory/skills/mech_interact_abci/skill.yaml
@@ -15,7 +15,7 @@ fingerprint:
   behaviours/mech_info.py: bafybeidajqcqn6mo2rparhopcunubvymrnyuuwxzx4xyviydcrwbjfrfou
   behaviours/mech_version.py: bafybeihxptnxmqslzfbquioym55l7holeykdtsd3avxy737qrocb5mmebu
   behaviours/offchain_request.py: bafybeiclfkjgt6bxsnvlkmprweglvesbmbz7l3ee73dn4ukuii6joqsvnq
-  behaviours/offchain_response.py: bafybeifaeznjs6kz6wcusb6jvbkepdzdudtkblo2shzintvogc6rkym4au
+  behaviours/offchain_response.py: bafybeih5ur6lqkch4s2o5zhwtcgh3rtunslwwsnztt2ywkbhmqq6hsyub4
   behaviours/purchase_subcription.py: bafybeieet7du56scd2cltnuy7xlvvrapvk7ugmnv426k2xfnmim4wj5bfy
   behaviours/request.py: bafybeig3tyl6pcdmlm7odp7oqrgijygwyflcmkqrbalnukz6zzmxtb2j4y
   behaviours/response.py: bafybeift7qcgnehlphp4muqdo5harabo3jpw5ufb7egsf6bqnj4slhv2gq
@@ -44,7 +44,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeih5gzn23htrkovh4mrlycygbpjdc4smq27hgfptrlg7ekndybavjy
   tests/behaviours/test_mech_version.py: bafybeidmjgq2cwqafq36j7irm4nf53ca6imkyvtbtetscltqwiu6ebb444
   tests/behaviours/test_offchain_request_helpers.py: bafybeifinbb4eqdo2o6wpzrikgxocm6hhaujduuh7hy4h4nd5np32x5fpe
-  tests/behaviours/test_offchain_response_poller.py: bafybeic5odn4yqnbam4pbapglyszua76p2d5ogvzgthl4svjppoz5hnijm
+  tests/behaviours/test_offchain_response_poller.py: bafybeicnvek2dsqexjjlj6lnpjun647si6ve6jtf5mvljw5iju56ewhd7a
   tests/behaviours/test_purchase_subscription.py: bafybeih2nd26wx6dpvycl2xlewmgqirjtwwtu6ge3gu4dhpby2aoogml5u
   tests/behaviours/test_request.py: bafybeifng4uhlb3j6fg3wriwt2rvhqh3smwvfo5ugzqjdyt36uua6t3k7y
   tests/behaviours/test_response.py: bafybeibni7zx4m7n3wktmlxyab4olt4rnduqzhaltfl7n3exru3om5fymy
@@ -66,14 +66,14 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeif6cfjeruji2ovns6dhc5qivvjr7t7rh5mmudgh5gvumezin26qne
+- valory/gnosis_safe:0.1.0:bafybeiek7zs3r5c4wspwwuvnhunc2ddvccbsuy3xccedbjffju5eywp3ju
 - valory/mech:0.1.0:bafybeid2v3rotkylgln5w2udm3nnmsrnw4g4nlkbwhqfwbte4kwlxup5l4
 - valory/mech_mm:0.1.0:bafybeiaez7w5ssgcmt5fqbue4oywhxmcojrnxqimzksuojsksxwaqvwo5u
-- valory/multisend:0.1.0:bafybeidl74hh6g34kgxay3fzapz26dhfmc6s2kjnt6edmaxgrklhge3omy
-- valory/erc20:0.1.0:bafybeig4tin5v5ahiiz4fysocl7gjhpjtgzko3w6cr2iz3q5a4bxutwewu
-- valory/agent_mech:0.1.0:bafybeieiqd6n7zfnfq2bq6oqf7tskzw3hwwb3vj4djtipkbne7cybpdrne
+- valory/multisend:0.1.0:bafybeifqtf24h7lhhbairveqmq2klhvbswajmbpoyqj4xrgye7c22pxubi
+- valory/erc20:0.1.0:bafybeibpuyikvpmtaraca4lqokf3kf6jlpmafkqm6oixnps3ig23jfbllq
+- valory/agent_mech:0.1.0:bafybeidrkuruvewbi7xmi7py26ylgpcslmr5yuyu4tw6o7uekolmsj2zqa
 - valory/mech_marketplace_legacy:0.1.0:bafybeifkolgdeaoiveuppykvxkvja7c7pphn6jyivnk6x3bjl72rqpsogm
-- valory/agent_registry:0.1.0:bafybeihq4z4goum5ie7xwx723ub3bmuqql5hpys6kzy5cvt5g6y4k7eooe
+- valory/agent_registry:0.1.0:bafybeia6gfxdfpr4apeqd6s4777d7yf6qya2slu3ccqmwiapxe72ckvsiq
 - valory/ierc1155:0.1.0:bafybeif3wfclopxa3panep4xzgodlfclgypm3balncxyuxbhhvgz7imulq
 - valory/nvm_balance_tracker_token:0.1.0:bafybeifwxkaobltpm77oh2b54kuclm4vtx2bzpuoowqfdemkex5gb5yyfa
 - valory/nvm_balance_tracker_native:0.1.0:bafybeibou3doazirk637cyey4o33pz7fpdm4hsgdj7vd2kctuqxtjgnmla
@@ -93,8 +93,8 @@ protocols:
 - valory/acn_data_share:0.1.0:bafybeieqisfr6lhaaesq37lk7vyaxza2h6nucshksgyo2djqfyf2saqo4i
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
-- valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
+- valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
+- valory/transaction_settlement_abci:0.1.0:bafybeibkhvngknsnluenxcxvzgs7s6z6ai62yfkce37nfwltge6aujplm4
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/mech_interact_abci/tests/behaviours/test_offchain_response_poller.py
+++ b/packages/valory/skills/mech_interact_abci/tests/behaviours/test_offchain_response_poller.py
@@ -53,10 +53,13 @@ class _StubBehaviour:
         pending: Any = None,
         mech_responses: Any = None,
     ) -> None:
+        self.warnings: List[str] = []
         self.context = SimpleNamespace(
             logger=SimpleNamespace(
                 info=lambda *a, **k: None,
-                warning=lambda *a, **k: None,
+                warning=lambda msg, *a, **k: self.warnings.append(
+                    msg % a if a else msg
+                ),
                 error=lambda *a, **k: None,
                 debug=lambda *a, **k: None,
             )
@@ -201,6 +204,60 @@ class TestPollUntilTerminal:
         snapshot = _drive(poller._poll_until_terminal("https://m", "42"))
         assert snapshot.status == "ok"
         assert snapshot.result == "Invalid response"
+
+    def test_ok_status_envelope_missing_result_key_warns(self) -> None:
+        """Schema drift: an ``ok`` envelope with no ``result`` key logs a warning.
+
+        Falling through silently would land in ``mech_responses`` as a
+        fake failed prediction (``result=None, error="Unknown"``),
+        indistinguishable from a routine tool failure. Emit a warning
+        so the drift is visible.
+        """
+        body = json.dumps(
+            {
+                "status": "ok",
+                "response": {
+                    "schema_version": "2.0",
+                    "requestId": "42",
+                    "tool": "prediction-online",
+                    "executed_at": "2026-07-02T14:24:27Z",
+                },
+            }
+        ).encode()
+        stub = _StubBehaviour(http_responses=[_http_response(200, body)])
+        poller = OffchainResponsePoller(stub)  # type: ignore[arg-type]
+        snapshot = _drive(poller._poll_until_terminal("https://m", "42"))
+        assert snapshot.status == "ok"
+        assert snapshot.result is None
+        assert any(
+            "missing 'result' key" in msg for msg in stub.warnings
+        ), stub.warnings
+
+    def test_ok_status_serialises_non_string_inner_result_to_json(self) -> None:
+        """Non-string inner ``result`` values are JSON-encoded for the downstream wire shape.
+
+        Pins the fallback branch of ``_serialise_result``: if a future
+        mech-executor variant returns the parsed prediction dict instead
+        of a JSON string, downstream still receives a string.
+        """
+        body = json.dumps(
+            {
+                "status": "ok",
+                "response": {
+                    "schema_version": "2.0",
+                    "requestId": "42",
+                    "result": {"p_yes": 0.6, "p_no": 0.4},
+                    "tool": "prediction-online",
+                    "executed_at": "2026-07-02T14:24:27Z",
+                },
+            }
+        ).encode()
+        stub = _StubBehaviour(http_responses=[_http_response(200, body)])
+        poller = OffchainResponsePoller(stub)  # type: ignore[arg-type]
+        snapshot = _drive(poller._poll_until_terminal("https://m", "42"))
+        assert snapshot.status == "ok"
+        assert isinstance(snapshot.result, str)
+        assert json.loads(snapshot.result) == {"p_yes": 0.6, "p_no": 0.4}
 
     def test_rejected_status_surfaces_reason(self) -> None:
         """A 200 with ``status="rejected"`` carries the reason as ``error``."""


### PR DESCRIPTION
## Summary

Two follow-ups to review nits on #98.

## 1. Missing `result` key silently yielded `None`

If the mech's response schema drifts (renamed field, truncated payload, added nesting), `envelope.get("result")` returned `None`, `_PollSnapshot` was constructed with `result=None`, and `_apply_snapshot` set `target.result=None`, `target.error="Unknown"`. That is indistinguishable from a routine tool failure and lands in `mech_responses` as a fake failed prediction.

Now logs a warning citing the observed envelope keys so the drift is visible. Every other structural failure in `_parse` either returns `processing` or emits a warning; this one now matches the convention.

## 2. Restored `_serialise_result` JSON-coercion coverage

The removed test used `{"answer": 1}` (dict) as the response value, exercising the non-string fallback (`json.dumps`). The two new tests on #98 feed string results, so nothing pinned the coercion branch.

Added:
- `test_ok_status_serialises_non_string_inner_result_to_json` — feeds `result={"p_yes": 0.6, "p_no": 0.4}` and asserts the snapshot result is the JSON-encoded string.
- `test_ok_status_envelope_missing_result_key_warns` — asserts the schema-drift warning fires. Stub logger now captures warnings into a list so tests can assert on them.

## Verification

- 14 tests pass in `test_offchain_response_poller.py` (12 pre-existing + 2 new)
- `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` all green
- `autonomy packages lock --check` green

## Follow-up to

Review comments on #98 (already merged into `feat/offchain-epic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)